### PR TITLE
Fix#43: DEV_MODE in auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ REDIS_PORT=6379
 BACKEND_PORT=8000
 # IMPORTANT: Generate a secure secret for production
 SECRET_KEY=change-me-in-production-use-openssl-rand-hex-32
+# Set DEBUG=true to enable dev credential login (no OIDC required)
+# NOTE: Dev mode also requires SECRET_KEY=change-me-in-production (the docker-compose default).
+# If you override SECRET_KEY, dev login will not activate.
+# DEBUG=true
 
 # Frontend Configuration
 # ============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       NEXT_PUBLIC_API_URL: http://backend:8000
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:-change-me-in-production}
+      DEV_MODE: ${DEBUG:-false}
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
     depends_on:

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -68,7 +68,7 @@ function getProviders() {
     providers.push(OIDCProvider);
   }
 
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.DEV_MODE === 'true' || process.env.NODE_ENV === 'development') {
     providers.push(DevCredentialsProvider);
   }
   return providers;


### PR DESCRIPTION
## Description

Bug is real and verified. The issue is in frontend/lib/auth.ts:71 — the DevCredentialsProvider was only registered when NODE_ENV === 'development', but Docker production images always set NODE_ENV=production. So
   when users run docker compose up with DEBUG=true (no dev overlay), NextAuth has zero providers registered and login is impossible.

  Verified locally:
  - Without fix: /api/auth/providers → {} (empty, can't log in)
  - With fix (DEV_MODE=true): /api/auth/providers → {"dev-credentials": {...}} (works)

  Changes:
  1. frontend/lib/auth.ts — Check DEV_MODE env var in addition to NODE_ENV
  2. docker-compose.yml — Pass DEV_MODE: ${DEBUG:-false} to the frontend container
  3. .env.example — Document the DEBUG option and its SECRET_KEY requirement


## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
<!-- Fixes #123 -->

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [ ] My code follows the project's coding style
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation as needed
- [ ] My changes don't introduce new warnings or errors

## Testing

<!-- Describe how you tested your changes -->

### Test Environment
- [ ] Docker Compose
- [ ] Kubernetes
- [ ] Local development

### Tests Performed
<!-- List the tests you ran to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->
