### PR TITLE
ci: install cognitive-cache via uv tool install

### DIFF
--- a/.github/workflows/issue-context.yml
+++ b/.github/workflows/issue-context.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: astral-sh/setup-uv@v4
 
       - name: Install cognitive-cache
-        run: uv pip install --system cognitive-cache
+        run: uv tool install cognitive-cache
 
       - name: Select relevant files
         id: select

--- a/.github/workflows/pr-context.yml
+++ b/.github/workflows/pr-context.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: astral-sh/setup-uv@v4
 
       - name: Install cognitive-cache
-        run: uv pip install --system cognitive-cache
+        run: uv tool install cognitive-cache
 
       - name: Get changed files
         id: diff


### PR DESCRIPTION
The system Python on Ubuntu 24.04 runners is PEP 668 externally
managed, so `uv pip install --system` fails. Switch to `uv tool
install`, which is the right fit since cognitive-cache is invoked
as a CLI and ends up on PATH automatically.