### PR TITLE
ci: publish Docker images to GHCR on main and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,8 +204,8 @@ jobs:
           context: ./backend
           push: false
           tags: wardrowbe/backend:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
 
       - name: Build frontend image
         uses: docker/build-push-action@v7
@@ -213,5 +213,5 @@ jobs:
           context: ./frontend
           push: false
           tags: wardrowbe/frontend:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -38,13 +41,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # GHCR rejects non-lowercase repository names, and GITHUB_REPOSITORY_OWNER
+      # can contain capitals (e.g. "Anyesh"), so lowercase it before tagging.
+      - name: Compute image base
+        id: image
+        run: echo "base=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/wardrowbe" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/wardrowbe:${{ matrix.tag_prefix }}-latest
-            ghcr.io/${{ github.repository_owner }}/wardrowbe:${{ matrix.tag_prefix }}-${{ github.sha }}
+            ${{ steps.image.outputs.base }}:${{ matrix.tag_prefix }}-latest
+            ${{ steps.image.outputs.base }}:${{ matrix.tag_prefix }}-${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,11 +41,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # GHCR rejects non-lowercase repository names, and GITHUB_REPOSITORY_OWNER
-      # can contain capitals (e.g. "Anyesh"), so lowercase it before tagging.
-      - name: Compute image base
-        id: image
-        run: echo "base=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/wardrowbe" >> "$GITHUB_OUTPUT"
+      - name: Resolve release version
+        if: github.event_name == 'release'
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # release-please tags look like wardrowbe-v1.3.0; strip the component
+          # prefix and leading v so that metadata-action can parse plain semver.
+          version="${TAG#*-}"
+          version="${version#v}"
+          echo "RELEASE_VERSION=${version}" >> "$GITHUB_ENV"
+
+      # metadata-action lowercases the image because GHCR rejects capitalized
+      # owners (e.g. "Anyesh") and derives the full tag set from the event.
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/wardrowbe
+          flavor: |
+            latest=true
+            prefix=${{ matrix.tag_prefix }}-,onlatest=true
+          tags: |
+            type=sha,format=long
+            type=semver,pattern={{version}},value=${{ env.RELEASE_VERSION }},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_VERSION }},enable=${{ github.event_name == 'release' }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -53,8 +73,7 @@ jobs:
           context: ${{ matrix.context }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ steps.image.outputs.base }}:${{ matrix.tag_prefix }}-latest
-            ${{ steps.image.outputs.base }}:${{ matrix.tag_prefix }}-${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,62 +6,51 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-  packages: write
+env:
+  GHCR_REGISTRY: ghcr.io
 
 jobs:
   publish:
     name: Publish ${{ matrix.service }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     strategy:
       fail-fast: false
       matrix:
         include:
           - service: backend
             context: ./backend
-            image: wardrowbe-backend
-            build_args: ""
+            tag_prefix: backend
           - service: frontend
             context: ./frontend
-            image: wardrowbe-frontend
-            build_args: ""
+            tag_prefix: frontend
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Log in to GitHub Container Registry
+      - name: Lowercase image name
+        run: echo "GHCR_IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=sha-,format=short
 
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ matrix.build_args }}
+          tags: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:${{ matrix.tag_prefix }}-latest
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:${{ matrix.tag_prefix }}-${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,9 +6,6 @@ on:
   release:
     types: [published]
 
-env:
-  GHCR_REGISTRY: ghcr.io
-
 jobs:
   publish:
     name: Publish ${{ matrix.service }}
@@ -34,13 +31,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Lowercase image name
-        run: echo "GHCR_IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
-
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.GHCR_REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -50,7 +44,7 @@ jobs:
           context: ${{ matrix.context }}
           push: true
           tags: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:${{ matrix.tag_prefix }}-latest
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}:${{ matrix.tag_prefix }}-${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/wardrowbe:${{ matrix.tag_prefix }}-latest
+            ghcr.io/${{ github.repository_owner }}/wardrowbe:${{ matrix.tag_prefix }}-${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,67 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: backend
+            context: ./backend
+            image: wardrowbe-backend
+            build_args: ""
+          - service: frontend
+            context: ./frontend
+            image: wardrowbe-frontend
+            build_args: ""
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.context }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ matrix.build_args }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/README.md
+++ b/README.md
@@ -128,8 +128,11 @@ cp .env.example .env
 
 #### Step 3: Start Services
 
+`docker-compose.yml` pulls pre-built multi-arch images (`linux/amd64` and `linux/arm64`, so Raspberry Pi and other ARM hosts work) from GitHub Container Registry. No local build tooling is required on the host.
+
 ```bash
-# Start all containers
+# Pull the latest published images, then start all containers
+docker compose pull
 docker compose up -d
 
 # Wait for services to be healthy (30 seconds)
@@ -142,6 +145,8 @@ docker compose exec backend alembic upgrade head
 curl http://localhost:8000/api/v1/health
 # Should return: {"status":"healthy"}
 ```
+
+To build the images from source instead of pulling them, use the development stack below (`docker-compose.dev.yml`), which builds locally and enables hot reload.
 
 #### Step 4: Access the App
 
@@ -268,9 +273,10 @@ AI_TEXT_MODEL=llama3.2-vision:11b  # Same model for both tasks
 
 ### Docker Compose (Production)
 
-See [docker-compose.prod.yml](docker-compose.prod.yml) for production configuration.
+See [docker-compose.prod.yml](docker-compose.prod.yml) for production configuration. Like the default stack, it pulls pre-built images from GHCR rather than building on the host.
 
 ```bash
+docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
 docker compose exec backend alembic upgrade head
 ```

--- a/README.md
+++ b/README.md
@@ -281,6 +281,11 @@ docker compose -f docker-compose.prod.yml up -d
 docker compose exec backend alembic upgrade head
 ```
 
+Images are tagged `backend-latest` / `frontend-latest`, and each release also
+publishes `backend-<version>` / `frontend-<version>` (e.g. `backend-1.3.0`). To
+pin a deployment to a specific release, replace the `-latest` tags in the
+compose file with the version, e.g. `ghcr.io/anyesh/wardrowbe:backend-1.3.0`.
+
 ### Kubernetes
 
 See the [k8s/](k8s/) directory for Kubernetes manifests including:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,6 +30,9 @@ services:
     restart: unless-stopped
 
   backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     volumes:
       - ./backend:/app
@@ -54,6 +57,9 @@ services:
       WATCHPACK_POLLING: "true"
 
   worker:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
     command: watchfiles --filter python "arq app.workers.worker.WorkerSettings" /app
     volumes:
       - ./backend:/app

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,9 +38,7 @@ services:
 
   # FastAPI Backend
   backend:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
+    image: ghcr.io/anyesh/wardrowbe-backend:latest
     container_name: wardrobe_backend
     restart: unless-stopped
     extra_hosts:
@@ -91,9 +89,7 @@ services:
 
   # arq Worker for background jobs
   worker:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
+    image: ghcr.io/anyesh/wardrowbe-backend:latest
     container_name: wardrobe_worker
     restart: unless-stopped
     command: arq app.workers.worker.WorkerSettings
@@ -130,11 +126,7 @@ services:
 
   # Next.js Frontend
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
-      args:
-        NEXT_PUBLIC_API_URL: ""
+    image: ghcr.io/anyesh/wardrowbe-frontend:latest
     container_name: wardrobe_frontend
     restart: unless-stopped
     extra_hosts:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,7 +38,7 @@ services:
 
   # FastAPI Backend
   backend:
-    image: ghcr.io/sirkitboard/wardrowbe:backend-latest
+    image: ghcr.io/anyesh/wardrowbe:backend-latest
     container_name: wardrobe_backend
     restart: unless-stopped
     extra_hosts:
@@ -89,7 +89,7 @@ services:
 
   # arq Worker for background jobs
   worker:
-    image: ghcr.io/sirkitboard/wardrowbe:backend-latest
+    image: ghcr.io/anyesh/wardrowbe:backend-latest
     container_name: wardrobe_worker
     restart: unless-stopped
     command: arq app.workers.worker.WorkerSettings
@@ -126,7 +126,7 @@ services:
 
   # Next.js Frontend
   frontend:
-    image: ghcr.io/sirkitboard/wardrowbe:frontend-latest
+    image: ghcr.io/anyesh/wardrowbe:frontend-latest
     container_name: wardrobe_frontend
     restart: unless-stopped
     extra_hosts:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,7 +38,7 @@ services:
 
   # FastAPI Backend
   backend:
-    image: ghcr.io/anyesh/wardrowbe-backend:latest
+    image: ghcr.io/sirkitboard/wardrowbe:backend-latest
     container_name: wardrobe_backend
     restart: unless-stopped
     extra_hosts:
@@ -89,7 +89,7 @@ services:
 
   # arq Worker for background jobs
   worker:
-    image: ghcr.io/anyesh/wardrowbe-backend:latest
+    image: ghcr.io/sirkitboard/wardrowbe:backend-latest
     container_name: wardrobe_worker
     restart: unless-stopped
     command: arq app.workers.worker.WorkerSettings
@@ -126,7 +126,7 @@ services:
 
   # Next.js Frontend
   frontend:
-    image: ghcr.io/anyesh/wardrowbe-frontend:latest
+    image: ghcr.io/sirkitboard/wardrowbe:frontend-latest
     container_name: wardrobe_frontend
     restart: unless-stopped
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,9 +35,7 @@ services:
 
   # FastAPI Backend
   backend:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
+    image: ghcr.io/anyesh/wardrowbe-backend:latest
     container_name: wardrobe-backend
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -78,9 +76,7 @@ services:
 
   # Next.js Frontend
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
+    image: ghcr.io/anyesh/wardrowbe-frontend:latest
     container_name: wardrobe-frontend
     environment:
       NEXT_PUBLIC_API_URL: http://backend:8000
@@ -95,9 +91,7 @@ services:
 
 # Background Worker for AI Tagging
   worker:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
+    image: ghcr.io/anyesh/wardrowbe-backend:latest
     container_name: wardrobe-worker
     command: arq app.workers.worker.WorkerSettings
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
 
   # FastAPI Backend
   backend:
-    image: ghcr.io/anyesh/wardrowbe-backend:latest
+    image: ghcr.io/sirkitboard/wardrowbe:backend-latest
     container_name: wardrobe-backend
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -76,7 +76,7 @@ services:
 
   # Next.js Frontend
   frontend:
-    image: ghcr.io/anyesh/wardrowbe-frontend:latest
+    image: ghcr.io/sirkitboard/wardrowbe:frontend-latest
     container_name: wardrobe-frontend
     environment:
       NEXT_PUBLIC_API_URL: http://backend:8000
@@ -91,7 +91,7 @@ services:
 
 # Background Worker for AI Tagging
   worker:
-    image: ghcr.io/anyesh/wardrowbe-backend:latest
+    image: ghcr.io/sirkitboard/wardrowbe:backend-latest
     container_name: wardrobe-worker
     command: arq app.workers.worker.WorkerSettings
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
 
   # FastAPI Backend
   backend:
-    image: ghcr.io/sirkitboard/wardrowbe:backend-latest
+    image: ghcr.io/anyesh/wardrowbe:backend-latest
     container_name: wardrobe-backend
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -76,7 +76,7 @@ services:
 
   # Next.js Frontend
   frontend:
-    image: ghcr.io/sirkitboard/wardrowbe:frontend-latest
+    image: ghcr.io/anyesh/wardrowbe:frontend-latest
     container_name: wardrobe-frontend
     environment:
       NEXT_PUBLIC_API_URL: http://backend:8000
@@ -91,7 +91,7 @@ services:
 
 # Background Worker for AI Tagging
   worker:
-    image: ghcr.io/sirkitboard/wardrowbe:backend-latest
+    image: ghcr.io/anyesh/wardrowbe:backend-latest
     container_name: wardrobe-worker
     command: arq app.workers.worker.WorkerSettings
     extra_hosts:


### PR DESCRIPTION
## Motivation

When deploying wardrowbe on a NAS or home server (e.g. Unraid) using Docker Compose, the current setup requires a full Docker build on the deployment machine. This means the server needs build tooling, all source dependencies, and enough CPU/RAM to compile the images — not something you want on a NAS that's just meant to run containers.

Publishing pre-built images to GHCR means deployments become a simple `docker compose pull && docker compose up -d`, with no build step needed on the host.

## Summary

- Add `.github/workflows/docker-publish.yml` that builds and pushes `wardrowbe-backend` and `wardrowbe-frontend` images to GitHub Container Registry on every push to `main` and on published releases
- Images are tagged `service-latest` and `service-<sha>`, with the registry path derived dynamically from `GITHUB_REPOSITORY`
- Builds for both `linux/amd64` and `linux/arm64` for Raspberry Pi compatibility
- Update `docker-compose.yml` and `docker-compose.prod.yml` to pull pre-built images from GHCR instead of building locally
- Scope GHA layer cache in `ci.yml` so the existing docker-build job and the new publish workflow don't collide

## Notes

- `worker` reuses the backend image with a different entrypoint command, consistent with the existing Dockerfile structure
- The dev compose (`docker-compose.dev.yml`) is unchanged — frontend still builds from `Dockerfile.dev` and backend/worker mount local code for hot-reload
- No additional secrets needed — only the default `GITHUB_TOKEN` with `packages: write` permission

## Test plan

- [ ] Push to `main` and confirm both images appear under Packages on the repo page
- [ ] On a fresh machine, confirm `docker compose pull && docker compose up -d` works without a local build step