### PR TITLE
feat: add Discord webhook notification channel

### DIFF
--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -44,6 +44,19 @@ class MattermostConfig(BaseModel):
         return v
 
 
+class DiscordConfig(BaseModel):
+    webhook_url: str
+
+    @field_validator("webhook_url")
+    @classmethod
+    def validate_webhook(cls, v: str) -> str:
+        if not v.startswith("https://"):
+            raise ValueError("Webhook URL must use HTTPS")
+        if "discord.com/api/webhooks/" not in v and "discordapp.com/api/webhooks/" not in v:
+            raise ValueError("Invalid Discord webhook URL format")
+        return v
+
+
 class EmailConfig(BaseModel):
     address: str
 
@@ -69,7 +82,7 @@ class ExpoPushConfig(BaseModel):
 
 # Notification settings schemas
 class NotificationSettingsBase(BaseModel):
-    channel: Literal["ntfy", "mattermost", "email", "expo_push"]
+    channel: Literal["ntfy", "mattermost", "email", "expo_push", "discord"]
     enabled: bool = True
     priority: int = 1
     config: dict

--- a/backend/app/services/notification_providers.py
+++ b/backend/app/services/notification_providers.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 
 import httpx
 
-from app.schemas.notification import EmailConfig, ExpoPushConfig, MattermostConfig, NtfyConfig
+from app.schemas.notification import DiscordConfig, EmailConfig, ExpoPushConfig, MattermostConfig, NtfyConfig
 
 logger = logging.getLogger(__name__)
 
@@ -151,6 +151,74 @@ class MattermostProvider:
         try:
             result = await self.send(
                 MattermostMessage(text="This is a test message from Wardrowbe.")
+            )
+            if result.get("success"):
+                return True, "Test notification sent successfully"
+            return False, result.get("error", "Unknown error")
+        except Exception as e:
+            return False, str(e)
+
+
+# Discord Provider
+@dataclass
+class DiscordEmbed:
+    title: str
+    description: str = ""
+    color: int = 0x3B82F6
+    fields: list[dict] = field(default_factory=list)
+    footer: str | None = None
+
+
+@dataclass
+class DiscordMessage:
+    embeds: list[DiscordEmbed]
+    username: str = "Wardrowbe"
+
+
+class DiscordProvider:
+    def __init__(self, config: DiscordConfig):
+        self.webhook_url = config.webhook_url
+
+    async def send(self, message: DiscordMessage) -> dict:
+        payload: dict = {
+            "username": message.username,
+            "embeds": [
+                {
+                    "title": e.title,
+                    "description": e.description,
+                    "color": e.color,
+                    "fields": e.fields,
+                    **({"footer": {"text": e.footer}} if e.footer else {}),
+                }
+                for e in message.embeds
+            ],
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+                response = await client.post(self.webhook_url, json=payload)
+
+                if response.status_code in (200, 204):
+                    return {"success": True}
+                else:
+                    error = f"HTTP {response.status_code}: {response.text}"
+                    logger.warning("Discord request failed: %s", error)
+                    return {"success": False, "error": error}
+        except Exception as e:
+            logger.exception("Discord send failed")
+            return {"success": False, "error": str(e)}
+
+    async def test_connection(self) -> tuple[bool, str]:
+        try:
+            result = await self.send(
+                DiscordMessage(
+                    embeds=[
+                        DiscordEmbed(
+                            title="Wardrowbe Test",
+                            description="This is a test notification from Wardrowbe.",
+                        )
+                    ]
+                )
             )
             if result.get("success"):
                 return True, "Test notification sent successfully"

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -13,8 +13,11 @@ from app.models.notification import Notification, NotificationSettings, Notifica
 from app.models.outfit import Outfit, OutfitItem
 from app.models.schedule import Schedule
 from app.models.user import User
-from app.schemas.notification import EmailConfig, ExpoPushConfig, MattermostConfig, NtfyConfig
+from app.schemas.notification import DiscordConfig, EmailConfig, ExpoPushConfig, MattermostConfig, NtfyConfig
 from app.services.notification_providers import (
+    DiscordEmbed,
+    DiscordMessage,
+    DiscordProvider,
     EmailMessage,
     EmailProvider,
     ExpoPushMessage,
@@ -151,6 +154,10 @@ class NotificationService:
             elif setting.channel == "expo_push":
                 success, message = await ExpoPushProvider(
                     ExpoPushConfig(**setting.config)
+                ).test_connection()
+            elif setting.channel == "discord":
+                success, message = await DiscordProvider(
+                    DiscordConfig(**setting.config)
                 ).test_connection()
             else:
                 return False, f"Unknown channel: {setting.channel}"
@@ -414,6 +421,11 @@ class NotificationDispatcher:
                 message = self._build_expo_push_message(outfit, user, for_tomorrow)
                 result = await provider.send(message)
 
+            elif channel_config.channel == "discord":
+                provider = DiscordProvider(DiscordConfig(**channel_config.config))
+                message = self._build_discord_message(outfit, user, for_tomorrow)
+                result = await provider.send(message)
+
             else:
                 return NotificationResult(
                     channel=channel_config.channel,
@@ -442,6 +454,19 @@ class NotificationDispatcher:
                 error=str(e),
             )
 
+    @staticmethod
+    def _get_highlights(outfit: Outfit) -> list[str]:
+        if outfit.ai_raw_response and isinstance(outfit.ai_raw_response, dict):
+            return outfit.ai_raw_response.get("highlights", [])[:3]
+        return []
+
+    @staticmethod
+    def _weather_text(outfit: Outfit) -> str:
+        if outfit.weather_data:
+            weather = outfit.weather_data
+            return f" | {weather.get('temperature', '?')}°C {weather.get('condition', '')}"
+        return ""
+
     def _build_ntfy_notification(
         self, outfit: Outfit, user: User, for_tomorrow: bool = False
     ) -> NtfyNotification:
@@ -466,15 +491,9 @@ class NotificationDispatcher:
         if outfit.reasoning:
             parts.append(outfit.reasoning)
 
-        # Add highlights from ai_raw_response if available
-        highlights = []
-        if outfit.ai_raw_response and isinstance(outfit.ai_raw_response, dict):
-            highlights = outfit.ai_raw_response.get("highlights", [])
-
-        if highlights and isinstance(highlights, list):
-            # Format highlights as bullet points
-            highlight_lines = [f"* {h}" for h in highlights[:3]]  # Limit to 3
-            parts.append("\n".join(highlight_lines))
+        highlights = self._get_highlights(outfit)
+        if highlights:
+            parts.append("\n".join(f"* {h}" for h in highlights))
 
         # Add styling tip if available
         if outfit.style_notes:
@@ -508,38 +527,24 @@ class NotificationDispatcher:
     def _build_mattermost_message(
         self, outfit: Outfit, user: User, for_tomorrow: bool = False
     ) -> MattermostMessage:
-        weather_text = ""
-        if outfit.weather_data:
-            weather = outfit.weather_data
-            weather_text = f" | {weather.get('temperature', '?')}C {weather.get('condition', '')}"
-
         day_label = "Tomorrow" if for_tomorrow else "Today"
         greeting = "Good evening" if for_tomorrow else "Good morning"
 
-        # Build message text with structured data
         text_parts = []
-
-        # Add headline (stored in reasoning)
         if outfit.reasoning:
             text_parts.append(f"**{outfit.reasoning}**")
 
-        # Add highlights from ai_raw_response as markdown list
-        highlights = []
-        if outfit.ai_raw_response and isinstance(outfit.ai_raw_response, dict):
-            highlights = outfit.ai_raw_response.get("highlights", [])
+        highlights = self._get_highlights(outfit)
+        if highlights:
+            text_parts.append("\n".join(f"- {h}" for h in highlights))
 
-        if highlights and isinstance(highlights, list):
-            highlight_lines = [f"- {h}" for h in highlights[:3]]
-            text_parts.append("\n".join(highlight_lines))
-
-        # Add styling tip
         if outfit.style_notes:
             text_parts.append(f"_Tip: {outfit.style_notes}_")
 
         attachment_text = "\n\n".join(text_parts) if text_parts else "Your outfit is ready!"
 
         attachment = MattermostAttachment(
-            title=f"{day_label}'s Outfit: {outfit.occasion.title()}{weather_text}",
+            title=f"{day_label}'s Outfit: {outfit.occasion.title()}{self._weather_text(outfit)}",
             text=attachment_text,
             color="#3B82F6",
         )
@@ -548,6 +553,39 @@ class NotificationDispatcher:
             text=f"{greeting}, {user.display_name}! Here's your outfit suggestion for {day_label.lower()}:",
             attachments=[attachment],
         )
+
+    def _build_discord_message(
+        self, outfit: Outfit, user: User, for_tomorrow: bool = False
+    ) -> DiscordMessage:
+        day_label = "Tomorrow" if for_tomorrow else "Today"
+        greeting = "Good evening" if for_tomorrow else "Good morning"
+
+        description_parts = [f"{greeting}, {user.display_name}!"]
+        if outfit.reasoning:
+            description_parts.append(outfit.reasoning)
+        description = "\n\n".join(description_parts)
+
+        fields = []
+        highlights = self._get_highlights(outfit)
+        if highlights:
+            fields.append({
+                "name": "Highlights",
+                "value": "\n".join(f"• {h}" for h in highlights),
+                "inline": False,
+            })
+
+        if outfit.style_notes:
+            fields.append({"name": "Tip", "value": outfit.style_notes, "inline": False})
+
+        embed = DiscordEmbed(
+            title=f"{day_label}'s Outfit: {outfit.occasion.title()}{self._weather_text(outfit)}",
+            description=description,
+            color=0x3B82F6,
+            fields=fields,
+            footer=f"View outfit → {self.app_url}/dashboard/history",
+        )
+
+        return DiscordMessage(embeds=[embed])
 
     def _build_email_message(
         self, outfit: Outfit, user: User, to: str, for_tomorrow: bool = False
@@ -566,16 +604,12 @@ class NotificationDispatcher:
         day_label = "Tomorrow" if for_tomorrow else "Today"
         occasion_escaped = html_mod.escape(outfit.occasion.title())
 
-        # Build highlights HTML
+        highlights = self._get_highlights(outfit)
         highlights_html = ""
-        highlights = []
-        if outfit.ai_raw_response and isinstance(outfit.ai_raw_response, dict):
-            highlights = outfit.ai_raw_response.get("highlights", [])
-
-        if highlights and isinstance(highlights, list):
+        if highlights:
             items_html = "".join(
                 f'<li style="color: #4B5563; margin: 5px 0;">{html_mod.escape(str(h))}</li>'
-                for h in highlights[:3]
+                for h in highlights
             )
             highlights_html = f"""
             <ul style="margin: 15px 0; padding-left: 20px;">
@@ -656,7 +690,7 @@ class NotificationDispatcher:
 
         if highlights:
             text_parts.append("")
-            for h in highlights[:3]:
+            for h in highlights:
                 text_parts.append(f"- {h}")
 
         if outfit.style_notes:

--- a/frontend/app/dashboard/notifications/page.tsx
+++ b/frontend/app/dashboard/notifications/page.tsx
@@ -13,6 +13,7 @@ import {
   Calendar,
   Mail,
   MessageSquare,
+  Hash,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -77,12 +78,14 @@ const CHANNEL_ICONS: Record<string, React.ReactNode> = {
   ntfy: <Bell className="h-5 w-5" />,
   mattermost: <MessageSquare className="h-5 w-5" />,
   email: <Mail className="h-5 w-5" />,
+  discord: <Hash className="h-5 w-5" />,
 };
 
 const CHANNEL_LABELS: Record<string, string> = {
   ntfy: 'ntfy Push',
   mattermost: 'Mattermost',
   email: 'Email',
+  discord: 'Discord',
 };
 
 function ChannelCard({
@@ -112,6 +115,7 @@ function ChannelCard({
                 {setting.channel === 'ntfy' && setting.config.topic}
                 {setting.channel === 'mattermost' && 'Webhook configured'}
                 {setting.channel === 'email' && setting.config.address}
+                {setting.channel === 'discord' && 'Webhook configured'}
               </p>
             </div>
           </div>
@@ -147,7 +151,7 @@ function ChannelCard({
 }
 
 interface ChannelFormData {
-  channel: 'ntfy' | 'mattermost' | 'email';
+  channel: 'ntfy' | 'mattermost' | 'email' | 'discord';
   enabled: boolean;
   priority: number;
   config: Record<string, string>;
@@ -165,7 +169,7 @@ function AddChannelDialog({
   userEmail?: string;
 }) {
   const [open, setOpen] = useState(false);
-  const [channel, setChannel] = useState<'ntfy' | 'mattermost' | 'email'>('ntfy');
+  const [channel, setChannel] = useState<'ntfy' | 'mattermost' | 'email' | 'discord'>('ntfy');
   const [config, setConfig] = useState<Record<string, string>>({});
   const [ntfyDefaults, setNtfyDefaults] = useState<{ server: string; token: string } | null>(null);
 
@@ -211,6 +215,10 @@ function AddChannelDialog({
       toast.error('Webhook URL is required for Mattermost');
       return;
     }
+    if (channel === 'discord' && !config.webhook_url?.trim()) {
+      toast.error('Webhook URL is required for Discord');
+      return;
+    }
     if (channel === 'email' && !config.address?.trim()) {
       toast.error('Email address is required');
       return;
@@ -236,7 +244,7 @@ function AddChannelDialog({
   const closeAndReset = () => {
     setOpen(false);
     setConfig({});
-    setChannel('ntfy');
+    setChannel('ntfy' as const);
   };
 
   return (
@@ -260,7 +268,7 @@ function AddChannelDialog({
               <Label>Channel Type</Label>
               <Select
                 value={channel}
-                onValueChange={(v: 'ntfy' | 'mattermost' | 'email') => {
+                onValueChange={(v: 'ntfy' | 'mattermost' | 'email' | 'discord') => {
                   setChannel(v);
                   setConfig({});
                 }}
@@ -272,6 +280,7 @@ function AddChannelDialog({
                   <SelectItem value="ntfy">ntfy Push Notifications</SelectItem>
                   <SelectItem value="mattermost">Mattermost</SelectItem>
                   <SelectItem value="email">Email</SelectItem>
+                  <SelectItem value="discord">Discord</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -343,6 +352,22 @@ function AddChannelDialog({
                   placeholder="you@example.com"
                   required
                 />
+              </div>
+            )}
+
+            {channel === 'discord' && (
+              <div className="space-y-2">
+                <Label htmlFor="discord-webhook">Webhook URL *</Label>
+                <Input
+                  id="discord-webhook"
+                  value={config.webhook_url || ''}
+                  onChange={(e) => setConfig({ ...config, webhook_url: e.target.value })}
+                  placeholder="https://discord.com/api/webhooks/..."
+                  required
+                />
+                <p className="text-xs text-muted-foreground">
+                  Create a webhook in your Discord channel settings under Integrations
+                </p>
               </div>
             )}
           </div>


### PR DESCRIPTION
Discord is a common hub for home server enthusiasts, and currently there's no way to get outfit notifications there without routing through a separate service. This adds Discord as a first-class notification channel alongside the existing ntfy, Mattermost, and email options.

## Changes

**Backend**
- `DiscordConfig` schema with webhook URL validation
- `DiscordProvider` that sends rich embeds (title, description, highlights, tip, footer link)
- Wired into `NotificationDispatcher` and `test_setting` alongside existing channels

**Frontend**
- Discord option in the Add Channel dialog with a webhook URL field and setup hint
- Channel card display consistent with other channels

**Refactor** (touched while adding Discord)
- Extracted `_get_highlights()` and `_weather_text()` as shared helpers on `NotificationDispatcher` — these were duplicated across all four notification builders. Also fixed an inconsistency where Mattermost was showing `C` instead of `°C`.

## Setup

In Discord: channel settings → Integrations → Webhooks → New Webhook → copy URL.