### PR TITLE
Fix item pair score initialization for learning service

### DIFF
--- a/backend/app/api/outfits.py
+++ b/backend/app/api/outfits.py
@@ -672,6 +672,7 @@ async def submit_feedback(
         feedback = outfit.feedback
     else:
         feedback = UserFeedback(outfit_id=outfit.id)
+        outfit.feedback = feedback
         db.add(feedback)
 
     if request.accepted is not None:

--- a/backend/app/services/learning_service.py
+++ b/backend/app/services/learning_service.py
@@ -302,40 +302,39 @@ class LearningService:
                     pair_score.times_rejected = (pair_score.times_rejected or 0) + 1
 
                 if feedback.rating is not None:
-                    pair_score.total_rating_sum = (pair_score.total_rating_sum or 0) + feedback.rating
+                    pair_score.total_rating_sum = (
+                        pair_score.total_rating_sum or 0
+                    ) + feedback.rating
                     pair_score.rating_count = (pair_score.rating_count or 0) + 1
 
-                    # Update occasion performance
-                    occasion = outfit.occasion
-                    occasion_perf = (
-                        dict(pair_score.occasion_performance) if pair_score.occasion_performance else {}
-                    )
-                    if occasion not in occasion_perf:
-                        occasion_perf[occasion] = {"count": 0, "positive": 0}
-                    occasion_perf[occasion]["count"] += 1
-                    if is_positive:
-                        occasion_perf[occasion]["positive"] += 1
-                    pair_score.occasion_performance = occasion_perf
+                occasion = outfit.occasion
+                occasion_perf = (
+                    dict(pair_score.occasion_performance) if pair_score.occasion_performance else {}
+                )
+                if occasion not in occasion_perf:
+                    occasion_perf[occasion] = {"count": 0, "positive": 0}
+                occasion_perf[occasion]["count"] += 1
+                if is_positive:
+                    occasion_perf[occasion]["positive"] += 1
+                pair_score.occasion_performance = occasion_perf
 
-                    # Update weather performance
-                    if outfit.weather_data:
-                        temp = outfit.weather_data.get("temperature")
-                        if temp is not None:
-                            temp_bucket = self._get_temp_bucket(temp)
-                            weather_perf = (
-                                dict(pair_score.weather_performance)
-                                if pair_score.weather_performance
-                                else {}
-                            )
-                            if temp_bucket not in weather_perf:
-                                weather_perf[temp_bucket] = {"count": 0, "positive": 0}
-                            weather_perf[temp_bucket]["count"] += 1
-                            if is_positive:
-                                weather_perf[temp_bucket]["positive"] += 1
-                            pair_score.weather_performance = weather_perf
+                if outfit.weather_data:
+                    temp = outfit.weather_data.get("temperature")
+                    if temp is not None:
+                        temp_bucket = self._get_temp_bucket(temp)
+                        weather_perf = (
+                            dict(pair_score.weather_performance)
+                            if pair_score.weather_performance
+                            else {}
+                        )
+                        if temp_bucket not in weather_perf:
+                            weather_perf[temp_bucket] = {"count": 0, "positive": 0}
+                        weather_perf[temp_bucket]["count"] += 1
+                        if is_positive:
+                            weather_perf[temp_bucket]["positive"] += 1
+                        pair_score.weather_performance = weather_perf
 
-                    # Recompute compatibility score
-                    pair_score.compatibility_score = self._compute_pair_compatibility(pair_score)
+                pair_score.compatibility_score = self._compute_pair_compatibility(pair_score)
 
             except Exception:
                 logger.exception(
@@ -403,7 +402,9 @@ class LearningService:
 
             # Strong positive signal - user chose this over our recommendation
             pair_score.times_paired = (pair_score.times_paired or 0) + 1
-            pair_score.times_accepted = (pair_score.times_accepted or 0) + 1  # Treat as accepted since user chose it
+            pair_score.times_accepted = (
+                pair_score.times_accepted or 0
+            ) + 1  # Treat as accepted since user chose it
 
             # Give a strong rating boost (equivalent to 5-star rating)
             pair_score.total_rating_sum = (pair_score.total_rating_sum or 0) + 5

--- a/backend/app/services/learning_service.py
+++ b/backend/app/services/learning_service.py
@@ -272,69 +272,77 @@ class LearningService:
         for item1, item2 in combinations(items, 2):
             id1, id2 = (item1.id, item2.id) if item1.id < item2.id else (item2.id, item1.id)
 
-            # Get or create pair score
-            result = await self.db.execute(
-                select(ItemPairScore).where(
-                    and_(
-                        ItemPairScore.user_id == outfit.user_id,
-                        ItemPairScore.item1_id == id1,
-                        ItemPairScore.item2_id == id2,
+            try:
+                # Get or create pair score
+                result = await self.db.execute(
+                    select(ItemPairScore).where(
+                        and_(
+                            ItemPairScore.user_id == outfit.user_id,
+                            ItemPairScore.item1_id == id1,
+                            ItemPairScore.item2_id == id2,
+                        )
                     )
                 )
-            )
-            pair_score = result.scalar_one_or_none()
+                pair_score = result.scalar_one_or_none()
 
-            if not pair_score:
-                pair_score = ItemPairScore(
-                    user_id=outfit.user_id,
-                    item1_id=id1,
-                    item2_id=id2,
-                )
-                self.db.add(pair_score)
-
-            # Update counts
-            pair_score.times_paired += 1
-
-            if feedback.accepted is True:
-                pair_score.times_accepted += 1
-            elif feedback.accepted is False:
-                pair_score.times_rejected += 1
-
-            if feedback.rating is not None:
-                pair_score.total_rating_sum += feedback.rating
-                pair_score.rating_count += 1
-
-            # Update occasion performance
-            occasion = outfit.occasion
-            occasion_perf = (
-                dict(pair_score.occasion_performance) if pair_score.occasion_performance else {}
-            )
-            if occasion not in occasion_perf:
-                occasion_perf[occasion] = {"count": 0, "positive": 0}
-            occasion_perf[occasion]["count"] += 1
-            if is_positive:
-                occasion_perf[occasion]["positive"] += 1
-            pair_score.occasion_performance = occasion_perf
-
-            # Update weather performance
-            if outfit.weather_data:
-                temp = outfit.weather_data.get("temperature")
-                if temp is not None:
-                    temp_bucket = self._get_temp_bucket(temp)
-                    weather_perf = (
-                        dict(pair_score.weather_performance)
-                        if pair_score.weather_performance
-                        else {}
+                if not pair_score:
+                    pair_score = ItemPairScore(
+                        user_id=outfit.user_id,
+                        item1_id=id1,
+                        item2_id=id2,
                     )
-                    if temp_bucket not in weather_perf:
-                        weather_perf[temp_bucket] = {"count": 0, "positive": 0}
-                    weather_perf[temp_bucket]["count"] += 1
+                    self.db.add(pair_score)
+
+                # Update counts
+                pair_score.times_paired = (pair_score.times_paired or 0) + 1
+
+                if feedback.accepted is True:
+                    pair_score.times_accepted = (pair_score.times_accepted or 0) + 1
+                elif feedback.accepted is False:
+                    pair_score.times_rejected = (pair_score.times_rejected or 0) + 1
+
+                if feedback.rating is not None:
+                    pair_score.total_rating_sum = (pair_score.total_rating_sum or 0) + feedback.rating
+                    pair_score.rating_count = (pair_score.rating_count or 0) + 1
+
+                    # Update occasion performance
+                    occasion = outfit.occasion
+                    occasion_perf = (
+                        dict(pair_score.occasion_performance) if pair_score.occasion_performance else {}
+                    )
+                    if occasion not in occasion_perf:
+                        occasion_perf[occasion] = {"count": 0, "positive": 0}
+                    occasion_perf[occasion]["count"] += 1
                     if is_positive:
-                        weather_perf[temp_bucket]["positive"] += 1
-                    pair_score.weather_performance = weather_perf
+                        occasion_perf[occasion]["positive"] += 1
+                    pair_score.occasion_performance = occasion_perf
 
-            # Recompute compatibility score
-            pair_score.compatibility_score = self._compute_pair_compatibility(pair_score)
+                    # Update weather performance
+                    if outfit.weather_data:
+                        temp = outfit.weather_data.get("temperature")
+                        if temp is not None:
+                            temp_bucket = self._get_temp_bucket(temp)
+                            weather_perf = (
+                                dict(pair_score.weather_performance)
+                                if pair_score.weather_performance
+                                else {}
+                            )
+                            if temp_bucket not in weather_perf:
+                                weather_perf[temp_bucket] = {"count": 0, "positive": 0}
+                            weather_perf[temp_bucket]["count"] += 1
+                            if is_positive:
+                                weather_perf[temp_bucket]["positive"] += 1
+                            pair_score.weather_performance = weather_perf
+
+                    # Recompute compatibility score
+                    pair_score.compatibility_score = self._compute_pair_compatibility(pair_score)
+
+            except Exception:
+                logger.exception(
+                    f"[_update_item_pair_scores] Exception processing pair {id1} + {id2} "
+                    f"for outfit {outfit.id}, user {outfit.user_id}"
+                )
+                raise
 
     async def _process_wore_instead(self, outfit: Outfit) -> None:
         """
@@ -394,12 +402,12 @@ class LearningService:
                 self.db.add(pair_score)
 
             # Strong positive signal - user chose this over our recommendation
-            pair_score.times_paired += 1
-            pair_score.times_accepted += 1  # Treat as accepted since user chose it
+            pair_score.times_paired = (pair_score.times_paired or 0) + 1
+            pair_score.times_accepted = (pair_score.times_accepted or 0) + 1  # Treat as accepted since user chose it
 
             # Give a strong rating boost (equivalent to 5-star rating)
-            pair_score.total_rating_sum += 5
-            pair_score.rating_count += 1
+            pair_score.total_rating_sum = (pair_score.total_rating_sum or 0) + 5
+            pair_score.rating_count = (pair_score.rating_count or 0) + 1
 
             # Recompute compatibility
             pair_score.compatibility_score = self._compute_pair_compatibility(pair_score)

--- a/backend/tests/test_learning_service.py
+++ b/backend/tests/test_learning_service.py
@@ -7,7 +7,7 @@ import pytest_asyncio
 from sqlalchemy import select
 
 from app.models.item import ClothingItem
-from app.models.learning import UserLearningProfile
+from app.models.learning import ItemPairScore, UserLearningProfile
 from app.models.outfit import Outfit, OutfitItem, OutfitSource, OutfitStatus, UserFeedback
 from app.models.user import User
 from app.services.learning_service import LearningService
@@ -193,3 +193,63 @@ class TestIncrementalEMA:
         profile = result.scalar_one_or_none()
         assert profile is not None
         assert profile.feedback_count >= 1
+
+
+class TestItemPairScores:
+    async def _seed_two_item_outfit(self, db_session, user_id, *, accepted, rating):
+        items = []
+        for color in ("blue", "black"):
+            item = ClothingItem(
+                id=uuid4(),
+                user_id=user_id,
+                type="shirt",
+                image_path="test.jpg",
+                primary_color=color,
+                style=["casual"],
+            )
+            db_session.add(item)
+            items.append(item)
+
+        outfit = Outfit(
+            id=uuid4(),
+            user_id=user_id,
+            occasion="casual",
+            status=OutfitStatus.accepted if accepted else OutfitStatus.rejected,
+            source=OutfitSource.on_demand,
+            weather_data={"temperature": 20, "condition": "clear"},
+        )
+        db_session.add(outfit)
+        await db_session.flush()
+
+        for pos, item in enumerate(items):
+            db_session.add(OutfitItem(outfit_id=outfit.id, item_id=item.id, position=pos))
+        db_session.add(UserFeedback(outfit_id=outfit.id, accepted=accepted, rating=rating))
+        await db_session.commit()
+        return outfit.id
+
+    @pytest.mark.asyncio
+    async def test_accept_without_rating_creates_pair_and_context(
+        self, db_session, test_user_for_learning
+    ):
+        user_id = test_user_for_learning.id
+        outfit_id = await self._seed_two_item_outfit(
+            db_session, user_id, accepted=True, rating=None
+        )
+
+        await LearningService(db_session).process_feedback(outfit_id, user_id)
+
+        rows = (
+            (
+                await db_session.execute(
+                    select(ItemPairScore).where(ItemPairScore.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        pair = rows[0]
+        assert pair.times_paired == 1
+        assert pair.times_accepted == 1
+        assert "casual" in (pair.occasion_performance or {})
+        assert pair.occasion_performance["casual"]["count"] == 1


### PR DESCRIPTION
## Description

- learning_service.py
  - Updated _update_item_pair_scores so counter fields are incremented safely when ItemPairScore is created.
  - Handles None values for times_paired, times_accepted, times_rejected, total_rating_sum, and rating_count before applying +=.
  - Prevents the TypeError: unsupported operand type(s) for +=: 'NoneType' and 'int' bug on first-time pair creation.
- outfits.py
  - Ensures outfit.feedback = feedback is set when feedback is created in submit_feedback.
  - This keeps the new feedback object connected to the outfit for downstream learning updates.

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
<!-- Fixes #123 -->

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Checklist

<!-- Mark completed items with an "x" -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the project's coding style
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation as needed
- [ ] My changes don't introduce new warnings or errors

## Testing

### Test Environment
- [x] Docker Compose
- [ ] Kubernetes
- [ ] Local development

### Tests Performed

- Reproduced the bug with an outfit containing 3 items.
- Verified the learning service now safely creates/upgrades ItemPairScore rows without crashing.
- Confirmed feedback is attached to the outfit when created during submit_feedback.

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->
