### PR TITLE
Fix outfit item picker pagination bug

### DIFF
--- a/frontend/app/dashboard/outfits/new/page.tsx
+++ b/frontend/app/dashboard/outfits/new/page.tsx
@@ -99,12 +99,13 @@ export default function StudioEditorPage() {
     setDraftPrompted(true);
   }, [draftPrompted, isEditMode]);
 
+  const draftItemCount = pendingDraft?.items.length ?? 0;
   const { data: draftItemsData } = useItems(
     pendingDraft
       ? { ids: pendingDraft.items.join(','), is_archived: false }
       : { is_archived: false },
     1,
-    50
+    draftItemCount > 0 ? draftItemCount : 50
   );
 
   const handleResumeDraft = useCallback(() => {

--- a/frontend/app/dashboard/outfits/new/page.tsx
+++ b/frontend/app/dashboard/outfits/new/page.tsx
@@ -36,6 +36,7 @@ import {
   saveDraft,
   type StudioDraft,
 } from '@/lib/studio/draft-storage';
+import type { Item } from '@/lib/types';
 import { isWornImmutableError } from '@/lib/studio/errors';
 import { computeEditLoadPhase } from '@/lib/studio/edit-load';
 
@@ -156,26 +157,24 @@ export default function StudioEditorPage() {
     [state.items]
   );
 
-  const handleToggle = useCallback((itemId: string) => {
-    const existing = state.items.find((i) => i.id === itemId);
+  const handleToggle = useCallback((item: Item) => {
+    const existing = state.items.find((i) => i.id === item.id);
     if (existing) {
-      dispatch({ type: 'REMOVE_ITEM', itemId });
+      dispatch({ type: 'REMOVE_ITEM', itemId: item.id });
       return;
     }
-    const fromData = draftItemsData?.items.find((i) => i.id === itemId);
-    if (!fromData) return;
     dispatch({
       type: 'ADD_ITEM',
       item: {
-        id: fromData.id,
-        type: fromData.type,
-        name: fromData.name ?? null,
-        thumbnail_url: fromData.thumbnail_url ?? null,
-        image_url: fromData.image_url ?? null,
-        primary_color: fromData.primary_color ?? null,
+        id: item.id,
+        type: item.type,
+        name: item.name ?? null,
+        thumbnail_url: item.thumbnail_url ?? null,
+        image_url: item.image_url ?? null,
+        primary_color: item.primary_color ?? null,
       },
     });
-  }, [state.items, draftItemsData]);
+  }, [state.items]);
 
   const handleSave = async (markWorn: boolean) => {
     if (state.items.length === 0) {

--- a/frontend/components/shared/item-picker.tsx
+++ b/frontend/components/shared/item-picker.tsx
@@ -13,7 +13,7 @@ const PAGE_SIZE = 24;
 
 interface ItemPickerProps {
   selectedIds: Set<string>;
-  onToggle: (itemId: string) => void;
+  onToggle: (item: Item) => void;
   hideNeedsWash?: boolean;
   filterType?: string;
   emptyMessage?: string;
@@ -118,7 +118,7 @@ export function ItemPicker({
               <button
                 key={item.id}
                 type="button"
-                onClick={() => onToggle(item.id)}
+                onClick={() => onToggle(item)}
                 className={cn(
                   'relative aspect-square rounded-lg overflow-hidden border-2 transition-all',
                   isSelected


### PR DESCRIPTION
## Description

Fixes an issue where items loaded through pagination in the outfit item picker could not be added to outfits.

Previously, the outfit creation page attempted to resolve selected items from `draftItemsData`, which only contained the first 50 items from the initial query. As a result, items loaded later by the paginated `ItemPicker` failed to be added.

This change updates the toggle flow to pass the full `Item` object from `ItemPicker` directly to the parent component instead of only passing the item ID.

## Related Issue

Fixes #92

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] CI/CD or build changes

## Checklist

* [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
* [x] My code follows the project's coding style
* [ ] I have added tests that prove my fix/feature works
* [ ] New and existing tests pass locally
* [ ] I have updated documentation as needed
* [x] My changes don't introduce new warnings or errors

## Testing

### Test Environment

* [ ] Docker Compose
* [ ] Kubernetes
* [ ] Local development

### Tests Performed

Not tested locally.

The fix was implemented based on the issue description and code analysis. The root cause appears to be that `handleToggle()` relied on `draftItemsData`, which only contained the first page of items.

## Screenshots (if applicable)

N/A

## Additional Notes

Would appreciate verification from someone with a working local setup.
