### PR TITLE
fix: make OIDC issuer URL trailing-slash agnostic

### DIFF
--- a/backend/app/utils/oidc.py
+++ b/backend/app/utils/oidc.py
@@ -41,7 +41,12 @@ async def validate_oidc_id_token(
         ) as client:
             disc_resp = await client.get(discovery_url)
             disc_resp.raise_for_status()
-            jwks_uri = disc_resp.json()["jwks_uri"]
+            discovery = disc_resp.json()
+            jwks_uri = discovery["jwks_uri"]
+            # Validate the token's iss claim against the provider's canonical issuer
+            # (the discovery metadata) rather than the configured env var, so a
+            # trailing slash on OIDC_ISSUER_URL cannot cause a false issuer mismatch.
+            expected_issuer = discovery.get("issuer", issuer_url.rstrip("/"))
     except httpx.HTTPError as e:
         logger.error("Failed to fetch OIDC discovery from %s: %s", issuer_url, e)
         raise ValueError("Failed to contact OIDC provider") from None
@@ -56,7 +61,7 @@ async def validate_oidc_id_token(
             signing_key.key,
             algorithms=["RS256", "ES256"],
             audience=audience,
-            issuer=issuer_url,
+            issuer=expected_issuer,
             options={"verify_exp": True},
         )
     except jwt.PyJWTError:

--- a/backend/tests/test_oidc.py
+++ b/backend/tests/test_oidc.py
@@ -1,0 +1,100 @@
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.utils import oidc
+
+CANONICAL_ISSUER = "https://auth.example.com/application/o/wardrobe/"
+CONFIGURED_ISSUER_NO_SLASH = "https://auth.example.com/application/o/wardrobe"
+CLIENT_ID = "wardrobe"
+
+FAKE_REQUEST = httpx.Request(
+    "GET", f"{CONFIGURED_ISSUER_NO_SLASH}/.well-known/openid-configuration"
+)
+
+
+@pytest.fixture
+def rsa_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _make_id_token(private_key, *, iss: str, aud: str = CLIENT_ID) -> str:
+    now = int(time.time())
+    return jwt.encode(
+        {"sub": "user-1", "iss": iss, "aud": aud, "iat": now, "exp": now + 3600},
+        private_key,
+        algorithm="RS256",
+    )
+
+
+def _discovery_response(issuer: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"issuer": issuer, "jwks_uri": f"{issuer.rstrip('/')}/jwks/"},
+        request=FAKE_REQUEST,
+    )
+
+
+def _patch_jwk_client(public_key):
+    signing_key = MagicMock()
+    signing_key.key = public_key
+    jwk_client = MagicMock()
+    jwk_client.get_signing_key_from_jwt.return_value = signing_key
+    return patch.object(oidc, "_get_jwk_client", return_value=jwk_client)
+
+
+class TestValidateOidcIdToken:
+    @pytest.mark.asyncio
+    async def test_accepts_token_when_issuer_claim_has_trailing_slash(self, rsa_key):
+        # Authentik issues iss with a trailing slash; the configured env var omits
+        # it. Validation must succeed because it checks the discovery issuer, not
+        # the raw configured URL.
+        token = _make_id_token(rsa_key, iss=CANONICAL_ISSUER)
+
+        with (
+            patch.object(
+                httpx.AsyncClient,
+                "get",
+                new=AsyncMock(return_value=_discovery_response(CANONICAL_ISSUER)),
+            ),
+            _patch_jwk_client(rsa_key.public_key()),
+        ):
+            payload = await oidc.validate_oidc_id_token(
+                token, CONFIGURED_ISSUER_NO_SLASH, CLIENT_ID
+            )
+
+        assert payload["sub"] == "user-1"
+        assert payload["iss"] == CANONICAL_ISSUER
+
+    @pytest.mark.asyncio
+    async def test_rejects_token_from_wrong_issuer(self, rsa_key):
+        token = _make_id_token(rsa_key, iss="https://evil.example.com/")
+
+        with (
+            patch.object(
+                httpx.AsyncClient,
+                "get",
+                new=AsyncMock(return_value=_discovery_response(CANONICAL_ISSUER)),
+            ),
+            _patch_jwk_client(rsa_key.public_key()),
+            pytest.raises(ValueError, match="Invalid OIDC token"),
+        ):
+            await oidc.validate_oidc_id_token(token, CONFIGURED_ISSUER_NO_SLASH, CLIENT_ID)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_discovery_unreachable(self, rsa_key):
+        token = _make_id_token(rsa_key, iss=CANONICAL_ISSUER)
+
+        with (
+            patch.object(
+                httpx.AsyncClient,
+                "get",
+                new=AsyncMock(side_effect=httpx.ConnectError("refused")),
+            ),
+            pytest.raises(ValueError, match="Failed to contact OIDC provider"),
+        ):
+            await oidc.validate_oidc_id_token(token, CONFIGURED_ISSUER_NO_SLASH, CLIENT_ID)

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -14,7 +14,7 @@ const OIDCProvider: OAuthConfig<OIDCProfile> = {
   id: 'oidc',
   name: 'SSO',
   type: 'oauth',
-  wellKnown: `${process.env.OIDC_ISSUER_URL}/.well-known/openid-configuration`,
+  wellKnown: `${process.env.OIDC_ISSUER_URL?.replace(/\/+$/, '')}/.well-known/openid-configuration`,
   clientId: process.env.OIDC_CLIENT_ID!,
   clientSecret: process.env.OIDC_CLIENT_SECRET!,
   authorization: {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
<!-- Fixes #123 -->

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [ ] My code follows the project's coding style
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation as needed
- [ ] My changes don't introduce new warnings or errors

## Testing

<!-- Describe how you tested your changes -->

### Test Environment
- [ ] Docker Compose
- [ ] Kubernetes
- [ ] Local development

### Tests Performed
<!-- List the tests you ran to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->