### PR TITLE
feat: add custom User-Agent header to JWKS client

### DIFF
--- a/backend/app/utils/oidc.py
+++ b/backend/app/utils/oidc.py
@@ -28,7 +28,17 @@ def _get_jwk_client(jwks_uri: str, ca_bundle: str | None) -> PyJWKClient:
     if cache_key in _jwk_clients and (now - cached_time) < JWKS_CACHE_TTL:
         return _jwk_clients[cache_key]
 
-    client = PyJWKClient(jwks_uri, ssl_context=_build_ssl_context(ca_bundle))
+    # Masks the request to prevent firewalls (like Cloudflare) from blocking urllib as a bot
+    custom_headers = {
+        "User-Agent": "Mozilla/5.0 (compatible; WardrowbeBackend/1.0)"
+    }
+
+    client = PyJWKClient(
+        jwks_uri, 
+        ssl_context=_build_ssl_context(ca_bundle),
+        headers=custom_headers
+    )
+
     _jwk_clients[cache_key] = client
     _jwks_cache_times[cache_key] = now
     return client

--- a/backend/app/utils/oidc.py
+++ b/backend/app/utils/oidc.py
@@ -29,14 +29,10 @@ def _get_jwk_client(jwks_uri: str, ca_bundle: str | None) -> PyJWKClient:
         return _jwk_clients[cache_key]
 
     # Masks the request to prevent firewalls (like Cloudflare) from blocking urllib as a bot
-    custom_headers = {
-        "User-Agent": "Mozilla/5.0 (compatible; WardrowbeBackend/1.0)"
-    }
+    custom_headers = {"User-Agent": "Mozilla/5.0 (compatible; WardrowbeBackend/1.0)"}
 
     client = PyJWKClient(
-        jwks_uri, 
-        ssl_context=_build_ssl_context(ca_bundle),
-        headers=custom_headers
+        jwks_uri, ssl_context=_build_ssl_context(ca_bundle), headers=custom_headers
     )
 
     _jwk_clients[cache_key] = client

--- a/backend/tests/test_oidc.py
+++ b/backend/tests/test_oidc.py
@@ -147,3 +147,16 @@ class TestGetJwkClient:
                 mock_ssl.assert_called_once_with("/certs/ca.pem")
                 _, kwargs = mock_cls.call_args
                 assert kwargs["ssl_context"] is mock_ssl.return_value
+
+    def test_custom_user_agent_passed_to_pyjwkclient(self):
+        oidc._jwk_clients.clear()
+        oidc._jwks_cache_times.clear()
+
+        uri = "https://auth.example.com/jwks/"
+        with patch("app.utils.oidc.PyJWKClient") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            oidc._get_jwk_client(uri, ca_bundle=None)
+            _, kwargs = mock_cls.call_args
+            assert kwargs["headers"] == {
+                "User-Agent": "Mozilla/5.0 (compatible; WardrowbeBackend/1.0)"
+            }


### PR DESCRIPTION
Added custom User-Agent header to PyJWKClient to prevent blocking by firewalls.

## Description

This PR fixes an issue where OIDC token validation fails with an `HTTP Error 403: Forbidden` when the backend attempts to fetch the public keys from the identity provider's JWKS endpoint. 

`PyJWKClient` internally uses Python's standard `urllib`, which sends `Python-urllib/<version>` as the default `User-Agent`. Many Web Application Firewalls (WAFs) and reverse proxies (like Cloudflare, Authelia, or Nginx) strictly block this specific User-Agent to prevent basic bot scraping. To resolve this, a custom `User-Agent` header was added to the `PyJWKClient` instantiation to correctly identify the application.

## Related Issue


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the project's coding style
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes don't introduce new warnings or errors

## Testing

### Test Environment
- [x] Docker Compose
- [ ] Kubernetes
- [ ] Local development

### Tests Performed
1. Sent a `POST` request to `/api/v1/auth/sync` with a valid OIDC token.
2. Verified that the backend successfully fetches the `jwks.json` endpoint without encountering a `403 Forbidden` error.

## Screenshots (if applicable)

N/A

## Additional Notes

The OIDC discovery step (`/.well-known/openid-configuration`) was not affected by this bug because it was executed using `httpx`, which uses a different `User-Agent`. Only the subsequent JWKS fetch failed because `PyJWKClient` relies on `urllib`.