### PR TITLE
fix: surface real cause when outfit suggestion AI response is truncated (#139)

### DIFF
--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -661,7 +661,33 @@ class AIService:
 
                         data = response.json()
                         used_model = data.get("model", endpoint.text_model)
-                        content = data["choices"][0]["message"]["content"]
+                        choice = data["choices"][0]
+                        message = choice["message"]
+                        content = message["content"]
+
+                        if not content or not content.strip():
+                            finish_reason = choice.get("finish_reason")
+                            reasoning = message.get("reasoning_content")
+                            if finish_reason == "length" and reasoning:
+                                detail = (
+                                    "its reasoning/thinking output consumed the entire "
+                                    "completion token budget before it produced a response"
+                                )
+                            elif finish_reason == "length":
+                                detail = "the response was cut off before any content was generated"
+                            else:
+                                detail = f"finish_reason={finish_reason!r}"
+                            last_error = AIResponseTruncatedError(
+                                f"{endpoint.name} (model: {used_model}) returned an empty "
+                                f"response: {detail}. Try raising AI_MAX_TOKENS (currently "
+                                f"{self.settings.ai_max_tokens}) or disabling extended "
+                                "thinking/reasoning mode for this model."
+                            )
+                            logger.warning(str(last_error))
+                            if attempt < self.settings.ai_max_retries - 1:
+                                continue
+                            break
+
                         logger.info(
                             f"Text generation successful via {endpoint.name} (model: {used_model})"
                         )
@@ -688,6 +714,19 @@ class AIService:
         if last_error:
             raise last_error
         raise RuntimeError("Failed to generate text - no endpoints available")
+
+
+class AIResponseTruncatedError(RuntimeError):
+    """Raised when a model's response was cut off before it produced any output content.
+
+    Reasoning-capable models (e.g. Qwen3, DeepSeek-R1) return their chain-of-thought in a
+    separate ``reasoning_content`` field, distinct from ``content``. If that reasoning
+    consumes the entire completion token budget, the API reports ``finish_reason ==
+    "length"`` with an empty ``content`` string. Downstream JSON parsing of an empty
+    string then fails with an unhelpful message, which used to get swallowed into a
+    generic "AI service is not available" error even though the endpoint responded
+    successfully. This error preserves the real cause so callers can surface it.
+    """
 
 
 class AIDisabledError(RuntimeError):

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -663,7 +663,7 @@ class AIService:
                         used_model = data.get("model", endpoint.text_model)
                         choice = data["choices"][0]
                         message = choice["message"]
-                        content = message["content"]
+                        content = message.get("content")
 
                         if not content or not content.strip():
                             finish_reason = choice.get("finish_reason")

--- a/backend/app/services/pairing_service.py
+++ b/backend/app/services/pairing_service.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import selectinload
 from app.models.item import ClothingItem, ItemStatus
 from app.models.outfit import FamilyOutfitRating, Outfit, OutfitItem, OutfitSource, OutfitStatus
 from app.models.user import User
-from app.services.ai_service import AIService, require_internal_ai
+from app.services.ai_service import AIResponseTruncatedError, AIService, require_internal_ai
 from app.utils.clothing import deduplicate_by_body_slot
 from app.utils.prompts import load_prompt
 from app.utils.timezone import get_user_today
@@ -214,6 +214,11 @@ class PairingService:
             logger.info(f"AI pairings generated (model: {result.model})")
             logger.debug(f"AI raw response: {result.content[:500]}")
             pairings_data = self._parse_ai_response(result.content)
+        except AIResponseTruncatedError as e:
+            # Preserve the specific, actionable cause: the endpoint responded
+            # successfully but produced no content (see AIResponseTruncatedError).
+            logger.error(f"AI pairing generation failed: {e}")
+            raise AIGenerationError(str(e)) from e
         except Exception as e:
             logger.error(f"AI pairing generation failed: {e}")
             raise AIGenerationError(

--- a/backend/app/services/recommendation_service.py
+++ b/backend/app/services/recommendation_service.py
@@ -22,7 +22,7 @@ from app.models.outfit import (
 )
 from app.models.preference import UserPreference
 from app.models.user import User
-from app.services.ai_service import AIService, require_internal_ai
+from app.services.ai_service import AIResponseTruncatedError, AIService, require_internal_ai
 from app.services.item_scorer import get_season, score_items
 from app.services.suggestion_cache import pop_suggestion, push_suggestions
 from app.services.weather_service import (
@@ -884,6 +884,12 @@ class RecommendationService:
 
         except AIRecommendationError:
             raise
+        except AIResponseTruncatedError as e:
+            # Preserve the specific, actionable cause instead of the generic message
+            # below — the AI endpoint responded successfully, it just didn't produce
+            # any output content (see AIResponseTruncatedError for why).
+            logger.error(f"AI recommendation failed: {e}")
+            raise AIRecommendationError(str(e)) from e
         except Exception as e:
             logger.error(f"AI recommendation failed: {e}")
             raise AIRecommendationError(

--- a/backend/tests/test_ai_service.py
+++ b/backend/tests/test_ai_service.py
@@ -1,4 +1,15 @@
-from app.services.ai_service import AIService, ClothingTags
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from app.services.ai_service import AIResponseTruncatedError, AIService, ClothingTags
+
+FAKE_REQUEST = httpx.Request("POST", "http://ai-endpoint.test/chat/completions")
+
+
+def _mock_response(json_data: dict, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=json_data, request=FAKE_REQUEST)
 
 
 class TestTagParsing:
@@ -166,3 +177,77 @@ class TestClothingTags:
         assert tags.primary_color == "navy"
         assert len(tags.colors) == 2
         assert tags.confidence == 0.92
+
+
+class TestGenerateTextTruncatedResponse:
+    """Regression tests for issue #139: reasoning-capable models (e.g. Qwen3 via
+
+    LM Studio) can exhaust the entire completion token budget on their
+    ``reasoning_content`` chain-of-thought, leaving ``message.content`` empty with
+    ``finish_reason == "length"``. That used to surface as an opaque "Could not parse
+    AI response as JSON: " error, further masked upstream as a generic "AI service is
+    not available" message. It should now raise AIResponseTruncatedError with the real
+    cause, every retry attempt, so callers can tell the user what actually happened.
+    """
+
+    @staticmethod
+    def _truncated_reasoning_response() -> dict:
+        # Mirrors the exact shape reported in the issue's attached LM Studio /
+        # backend logs: assistant content is empty, the model's chain-of-thought
+        # landed in reasoning_content instead, and finish_reason is "length".
+        return {
+            "id": "chatcmpl-j0ue2a2xp0kziw0f8gof",
+            "object": "chat.completion",
+            "model": "qwen/qwen3.5-9b",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning_content": "The user wants me to create 3 outfits...",
+                        "tool_calls": [],
+                    },
+                    "finish_reason": "length",
+                }
+            ],
+            "usage": {"prompt_tokens": 3417, "completion_tokens": 4775, "total_tokens": 8192},
+        }
+
+    @pytest.mark.asyncio
+    async def test_empty_content_with_reasoning_raises_truncated_error(self):
+        service = AIService()
+        mock_response = _mock_response(self._truncated_reasoning_response())
+
+        with patch("httpx.AsyncClient.post", return_value=mock_response):
+            with pytest.raises(AIResponseTruncatedError) as exc_info:
+                await service.generate_text("suggest an outfit")
+
+        message = str(exc_info.value)
+        assert "reasoning" in message
+        assert "AI_MAX_TOKENS" in message
+
+    @pytest.mark.asyncio
+    async def test_empty_content_without_reasoning_still_raises_truncated_error(self):
+        service = AIService()
+        payload = self._truncated_reasoning_response()
+        del payload["choices"][0]["message"]["reasoning_content"]
+        mock_response = _mock_response(payload)
+
+        with patch("httpx.AsyncClient.post", return_value=mock_response):
+            with pytest.raises(AIResponseTruncatedError):
+                await service.generate_text("suggest an outfit")
+
+    @pytest.mark.asyncio
+    async def test_normal_response_is_unaffected(self):
+        service = AIService()
+        payload = self._truncated_reasoning_response()
+        payload["choices"][0]["message"]["content"] = '{"outfits": []}'
+        payload["choices"][0]["message"]["reasoning_content"] = ""
+        payload["choices"][0]["finish_reason"] = "stop"
+        mock_response = _mock_response(payload)
+
+        with patch("httpx.AsyncClient.post", return_value=mock_response):
+            content = await service.generate_text("suggest an outfit")
+
+        assert content == '{"outfits": []}'

--- a/backend/tests/test_ai_service.py
+++ b/backend/tests/test_ai_service.py
@@ -239,6 +239,20 @@ class TestGenerateTextTruncatedResponse:
                 await service.generate_text("suggest an outfit")
 
     @pytest.mark.asyncio
+    async def test_missing_content_key_raises_truncated_error(self):
+        # Some providers omit the "content" key entirely instead of returning ""
+        # when the response is truncated; bracket access would raise KeyError
+        # instead of the actionable AIResponseTruncatedError.
+        service = AIService()
+        payload = self._truncated_reasoning_response()
+        del payload["choices"][0]["message"]["content"]
+        mock_response = _mock_response(payload)
+
+        with patch("httpx.AsyncClient.post", return_value=mock_response):
+            with pytest.raises(AIResponseTruncatedError):
+                await service.generate_text("suggest an outfit")
+
+    @pytest.mark.asyncio
     async def test_normal_response_is_unaffected(self):
         service = AIService()
         payload = self._truncated_reasoning_response()


### PR DESCRIPTION
## Description

Fixes #139.

The issue's attached backend + LM Studio logs pin down the actual failure
mechanism (I did not have an equivalent AI endpoint to reproduce the full
end-to-end flow, but the logs contain the exact API response shape, which
is enough to reproduce the failure precisely in a unit test — see below):

- The model in the report is a reasoning-capable Qwen3 build. Reasoning
  models return their chain-of-thought in a separate `reasoning_content`
  field, distinct from `content`.
- In the logs, the model spent its *entire* completion token budget on
  `reasoning_content` and never got to writing `content`. The response
  came back with `content: ""`, `finish_reason: "length"`.
- `RecommendationService._parse_ai_response` then fails to parse `""` as
  JSON (`Could not parse AI response as JSON: ` — matches the log line
  exactly, note the empty string after the colon).
- That `ValueError` is caught by a broad `except Exception` in
  `generate_recommendation` and replaced with a generic, misleading
  message: "AI service is not available. Please check your AI endpoint
  configuration in Settings." The AI service *was* available and *was*
  correctly configured — it just didn't produce any output content.

I also grepped the whole codebase for the literal string "An error has
occured"/"occurred" — it does not exist anywhere in the frontend. The
issue title/body is the reporter's own paraphrase of what they saw, not a
literal string bug, so there's nothing to fix there.

## Fix

- `AIService.generate_text()` now checks for empty/blank `content` right
  after extracting the API response. If found, it inspects `finish_reason`
  and `reasoning_content` to build a specific, actionable error
  (`AIResponseTruncatedError`), e.g. "returned an empty response: its
  reasoning/thinking output consumed the entire completion token budget
  before it produced a response... Try raising AI_MAX_TOKENS (currently
  8000) or disabling extended thinking/reasoning mode for this model."
- This is treated like the existing retryable HTTP failures in the same
  loop — it retries (up to `AI_MAX_RETRIES`) before giving up, since
  whether the model finishes reasoning in time is non-deterministic.
- `RecommendationService.generate_recommendation` now catches
  `AIResponseTruncatedError` explicitly and re-raises it with its own
  specific message, instead of letting the generic `except Exception`
  handler stomp it with the "AI service is not available" text.

## Scope

This is deliberately scoped to the outfit-suggestion path
(`ai_service.py` / `recommendation_service.py`), which is what #139
reports. `pairing_service.py` has the same `_parse_ai_response` /
generic-error pattern and likely has the same latent issue, but that's a
separate code path (see #140, which is about pairings UI copy, not this
bug) — left out of this PR to keep it minimal and reviewable. Happy to
follow up there if maintainers want it.

I was not able to fully reproduce the end-to-end flow (would need a local
reasoning-model endpoint like the reporter's LM Studio + Qwen3 setup), but
I reproduced the exact failure mechanism with a unit test built from the
literal response payload shape captured in the issue's attached logs, and
verified the fix resolves it while leaving normal responses unaffected.

## Testing

- Added `TestGenerateTextTruncatedResponse` in
  `backend/tests/test_ai_service.py`:
  - empty `content` + `reasoning_content` + `finish_reason: "length"` →
    raises `AIResponseTruncatedError` mentioning the reasoning cause and
    `AI_MAX_TOKENS`
  - empty `content` without `reasoning_content` → still raises
    `AIResponseTruncatedError` (generic truncation)
  - normal non-empty `content` response → unaffected, still returns
    content
- Ran the full backend suite locally (Postgres + Redis via
  `docker compose up postgres redis`): `386 passed`.
- `ruff check` and `ruff format --check` pass on all changed files.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the project's coding style
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation as needed (no user-facing docs affected)
- [x] My changes don't introduce new warnings or errors