### PR TITLE
fix: retry AI tagging without logprobs when the provider rejects it

### DIFF
--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -169,6 +169,10 @@ def compute_tag_completeness(tags: "ClothingTags") -> float:
     return round(score, 2)
 
 
+def _response_rejects_logprobs(response: httpx.Response) -> bool:
+    return response.status_code == 400 and "logprobs" in response.text.lower()
+
+
 _CONFIDENCE_FIELDS = {"type", "primary_color", "pattern", "material", "formality"}
 
 
@@ -451,9 +455,11 @@ class AIService:
         for endpoint in self._endpoints:
             logger.info(f"Trying AI endpoint for {task_name}: {endpoint.name}")
             model = endpoint.vision_model if use_vision_model else endpoint.text_model
+            use_logprobs = request_logprobs
 
             async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
-                for attempt in range(self.settings.ai_max_retries):
+                attempt = 0
+                while attempt < self.settings.ai_max_retries:
                     try:
                         request_body = {
                             "model": model,
@@ -461,7 +467,7 @@ class AIService:
                             "stream": False,
                             "max_tokens": self.settings.ai_max_tokens,
                         }
-                        if request_logprobs:
+                        if use_logprobs:
                             request_body["logprobs"] = True
                             request_body["top_logprobs"] = 3
 
@@ -476,7 +482,7 @@ class AIService:
                         choice = data["choices"][0]
                         content = choice["message"]["content"]
                         logprobs_content = None
-                        if request_logprobs:
+                        if use_logprobs:
                             lp = choice.get("logprobs")
                             if lp:
                                 logprobs_content = lp.get("content")
@@ -488,15 +494,26 @@ class AIService:
                         return content, None, logprobs_content
 
                     except httpx.HTTPStatusError as e:
+                        # Some providers (e.g. Gemini's OpenAI-compat endpoint, or Gemini
+                        # native without the paid tier) reject the logprobs param outright.
+                        # Retry the same attempt without it instead of burning the retry
+                        # budget or losing the tags entirely - this doesn't count against
+                        # ai_max_retries since it's a capability mismatch, not a transient
+                        # failure.
+                        if use_logprobs and _response_rejects_logprobs(e.response):
+                            logger.warning(
+                                f"{endpoint.name} rejected logprobs for {task_name}, "
+                                f"retrying without it: {e}"
+                            )
+                            use_logprobs = False
+                            continue
                         last_error = e
                         logger.warning(f"HTTP error from {endpoint.name}: {e}")
-                        if attempt < self.settings.ai_max_retries - 1:
-                            continue
                     except httpx.RequestError as e:
                         last_error = e
                         logger.warning(f"Request error from {endpoint.name}: {e}")
-                        if attempt < self.settings.ai_max_retries - 1:
-                            continue
+
+                    attempt += 1
 
         return None, last_error, None
 

--- a/backend/tests/test_ai_service.py
+++ b/backend/tests/test_ai_service.py
@@ -265,3 +265,81 @@ class TestGenerateTextTruncatedResponse:
             content = await service.generate_text("suggest an outfit")
 
         assert content == '{"outfits": []}'
+
+
+class TestLogprobsRejection:
+    """Regression tests for issue #143: providers like Gemini reject the
+
+    logprobs/top_logprobs request params with a 400, which used to burn every
+    retry attempt and leave tags empty (while the separate, logprobs-free
+    description call succeeded silently, giving no indication of the failure).
+    """
+
+    _TAGS_CONTENT = '{"type": "shirt", "primary_color": "blue", "colors": ["blue"]}'
+
+    @staticmethod
+    def _logprobs_rejected_response() -> httpx.Response:
+        # Mirrors Gemini's OpenAI-compat error shape from the issue report.
+        return _mock_response(
+            {"error": {"message": 'Unknown name "logprobs": Cannot find field.'}},
+            status_code=400,
+        )
+
+    @staticmethod
+    def _success_response(content: str) -> httpx.Response:
+        return _mock_response(
+            {
+                "model": "gemini-2.0-flash",
+                "choices": [{"message": {"content": content}}],
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_retries_without_logprobs_after_rejection(self):
+        service = AIService()
+        responses = [self._logprobs_rejected_response(), self._success_response(self._TAGS_CONTENT)]
+
+        with patch("httpx.AsyncClient.post", side_effect=responses) as mock_post:
+            content, err, logprobs_content = await service._call_with_fallback(
+                [{"role": "user", "content": "tag this"}], "tags", request_logprobs=True
+            )
+
+        assert err is None
+        assert content == self._TAGS_CONTENT
+        assert logprobs_content is None
+        assert mock_post.call_count == 2
+        first_body = mock_post.call_args_list[0].kwargs["json"]
+        second_body = mock_post.call_args_list[1].kwargs["json"]
+        assert first_body["logprobs"] is True
+        assert "logprobs" not in second_body
+        assert "top_logprobs" not in second_body
+
+    @pytest.mark.asyncio
+    async def test_logprobs_rejection_does_not_consume_retry_budget(self):
+        service = AIService()
+        service.settings = service.settings.model_copy(update={"ai_max_retries": 1})
+        responses = [self._logprobs_rejected_response(), self._success_response(self._TAGS_CONTENT)]
+
+        with patch("httpx.AsyncClient.post", side_effect=responses) as mock_post:
+            content, err, _ = await service._call_with_fallback(
+                [{"role": "user", "content": "tag this"}], "tags", request_logprobs=True
+            )
+
+        assert err is None
+        assert content == self._TAGS_CONTENT
+        assert mock_post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_unrelated_400_is_not_treated_as_logprobs_rejection(self):
+        service = AIService()
+        service.settings = service.settings.model_copy(update={"ai_max_retries": 1})
+        unrelated_400 = _mock_response({"error": {"message": "invalid model"}}, status_code=400)
+
+        with patch("httpx.AsyncClient.post", return_value=unrelated_400) as mock_post:
+            content, err, _ = await service._call_with_fallback(
+                [{"role": "user", "content": "tag this"}], "tags", request_logprobs=True
+            )
+
+        assert content is None
+        assert err is not None
+        assert mock_post.call_count == 1


### PR DESCRIPTION
Fixes #143: Gemini (both its OpenAI-compat endpoint and its native API via a proxy) returns 400 for the logprobs/top_logprobs params the tags call always sent, so the tags request failed every retry while the separate, logprobs-free description call succeeded - silently leaving items with a description but no tags and no visible error.

On a 400 whose body mentions "logprobs", retry the same attempt with it disabled instead of consuming the retry budget; the logprobs-based confidence score is simply skipped for that endpoint.

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
<!-- Fixes #123 -->

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [ ] My code follows the project's coding style
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation as needed
- [ ] My changes don't introduce new warnings or errors

## Testing

<!-- Describe how you tested your changes -->

### Test Environment
- [ ] Docker Compose
- [ ] Kubernetes
- [ ] Local development

### Tests Performed
<!-- List the tests you ran to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->
