### PR TITLE
feat: external outfit authoring for suggestions and pairings

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -34,8 +34,8 @@ async def capabilities() -> dict[str, Any]:
         },
         "features": {
             "external_tagging": True,
-            "external_suggestions": False,
-            "external_pairings": False,
+            "external_suggestions": True,
+            "external_pairings": True,
         },
         "version": "1.0.0",
     }

--- a/backend/app/api/outfits.py
+++ b/backend/app/api/outfits.py
@@ -557,6 +557,10 @@ async def create_external_suggestion(
         ) from None
 
     await db.commit()
+    # No learning pass here, unlike the studio path: that one synthesizes accepted feedback, while
+    # an authored suggestion lands pending and unrated, so process_feedback would return early.
+    # Learning fires when the user actually accepts or rates it.
+    await clear_suggestions(current_user.id, request.occasion)
 
     full = await service.get_full_outfit(outfit.id)
     return outfit_to_response(full)

--- a/backend/app/api/outfits.py
+++ b/backend/app/api/outfits.py
@@ -1126,7 +1126,7 @@ def _check_studio_kill_switch() -> None:
         )
 
 
-class StudioCreateRequest(BaseModel):
+class StudioCreateRequest(OutfitAttributeFields):
     model_config = ConfigDict(extra="forbid")
 
     items: list[UUID] = Field(min_length=1, max_length=20)
@@ -1203,6 +1203,10 @@ async def create_studio_outfit(
             scheduled_for=request.scheduled_for,
             mark_worn=request.mark_worn,
             source_item_id=request.source_item_id,
+            season=request.season,
+            formality=request.formality,
+            palette=request.palette,
+            notes=request.notes,
         )
     except ItemOwnershipError:
         raise HTTPException(

--- a/backend/app/api/outfits.py
+++ b/backend/app/api/outfits.py
@@ -22,7 +22,9 @@ from app.models.outfit import (
 )
 from app.models.user import User
 from app.schemas.item import DEFAULT_WASH_INTERVALS
+from app.schemas.outfit import MAX_AUTHORING_TEXT_LENGTH, OutfitAttributeFields
 from app.services.ai_service import AIDisabledError
+from app.services.external_outfit_service import ExternalOutfitService
 from app.services.item_service import ItemService
 from app.services.learning_service import LearningService
 from app.services.outfit_service import OutfitListFilters, OutfitService
@@ -188,6 +190,10 @@ class OutfitResponse(BaseModel):
     source: str
     reasoning: str | None = None
     style_notes: str | None = None
+    season: str | None = None
+    formality: str | None = None
+    palette: list[str] | None = None
+    notes: str | None = None
     highlights: list[str] | None = None
     weather: dict | None = None
     items: list[OutfitItemResponse]
@@ -404,6 +410,10 @@ def outfit_to_response(
         source=outfit.source.value,
         reasoning=outfit.reasoning,
         style_notes=outfit.style_notes,
+        season=outfit.season,
+        formality=outfit.formality,
+        palette=outfit.palette,
+        notes=outfit.notes,
         highlights=highlights,
         weather=outfit.weather_data,
         items=items,
@@ -486,6 +496,70 @@ async def suggest_outfit(
 
     wore_instead_map = await fetch_wore_instead_items_map(db, [outfit], user_id=current_user.id)
     return outfit_to_response(outfit, wore_instead_map, is_starter_suggestion=is_starter)
+
+
+class SuggestionCreateRequest(OutfitAttributeFields):
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[UUID] = Field(min_length=1, max_length=20)
+    occasion: str = Field(max_length=50)
+    name: Annotated[str | None, Field(max_length=100)] = None
+    scheduled_for: date | None = Field(
+        default=None, description="Defaults to the user's current date"
+    )
+    reasoning: Annotated[str | None, Field(max_length=MAX_AUTHORING_TEXT_LENGTH)] = None
+    style_notes: Annotated[str | None, Field(max_length=MAX_AUTHORING_TEXT_LENGTH)] = None
+
+    @field_validator("occasion")
+    @classmethod
+    def validate_occasion(cls, v: str) -> str:
+        v = v.strip().lower()
+        if v not in VALID_OCCASIONS:
+            raise ValueError(
+                f"Invalid occasion '{v}'. Must be one of: {', '.join(sorted(VALID_OCCASIONS))}"
+            )
+        return v
+
+
+@router.post("/suggestions", response_model=OutfitResponse, status_code=status.HTTP_201_CREATED)
+async def create_external_suggestion(
+    request: SuggestionCreateRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> OutfitResponse:
+    """Persist an externally-authored suggestion; available regardless of the AI flags."""
+    await rate_limit_by_user(
+        str(current_user.id), "external_suggestion", max_requests=20, window_seconds=60
+    )
+
+    service = ExternalOutfitService(db)
+    try:
+        outfit = await service.create_suggestion(
+            user=current_user,
+            item_ids=request.items,
+            occasion=request.occasion,
+            name=request.name,
+            scheduled_for=request.scheduled_for,
+            reasoning=request.reasoning,
+            style_notes=request.style_notes,
+            season=request.season,
+            formality=request.formality,
+            palette=request.palette,
+            notes=request.notes,
+        )
+    except ItemOwnershipError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error_code": "OUTFIT_ITEM_OWNERSHIP",
+                "message": "One or more items do not belong to you",
+            },
+        ) from None
+
+    await db.commit()
+
+    full = await service.get_full_outfit(outfit.id)
+    return outfit_to_response(full)
 
 
 @router.get("", response_model=OutfitListResponse)

--- a/backend/app/api/pairings.py
+++ b/backend/app/api/pairings.py
@@ -4,20 +4,25 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.models.outfit import Outfit, OutfitSource
+from app.models.outfit import Outfit
 from app.models.user import User
+from app.schemas.outfit import MAX_AUTHORING_TEXT_LENGTH, OutfitAttributeFields
 from app.services.ai_service import AIDisabledError
+from app.services.external_outfit_service import ExternalOutfitService
 from app.services.pairing_service import (
+    PAIRING_SOURCE_CLAUSE,
     AIGenerationError,
     InsufficientItemsError,
     PairingService,
 )
+from app.services.studio_service import ItemOwnershipError
 from app.utils.auth import get_current_user
+from app.utils.rate_limit import rate_limit_by_user
 from app.utils.signed_urls import sign_image_url
 
 logger = logging.getLogger(__name__)
@@ -101,6 +106,10 @@ class PairingResponse(BaseModel):
     source: str
     reasoning: str | None = None
     style_notes: str | None = None
+    season: str | None = None
+    formality: str | None = None
+    palette: list[str] | None = None
+    notes: str | None = None
     highlights: list[str] | None = None
     source_item: SourceItemResponse | None = None
     items: list[PairingItemResponse]
@@ -202,6 +211,10 @@ def pairing_to_response(outfit: Outfit) -> PairingResponse:
         source=outfit.source.value,
         reasoning=outfit.reasoning,
         style_notes=outfit.style_notes,
+        season=outfit.season,
+        formality=outfit.formality,
+        palette=outfit.palette,
+        notes=outfit.notes,
         highlights=highlights,
         source_item=source_item_response,
         items=items,
@@ -306,6 +319,72 @@ async def list_item_pairings(
     )
 
 
+class PairingCreateRequest(OutfitAttributeFields):
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[UUID] = Field(
+        min_length=1, max_length=20, description="Partner items to pair with the source item"
+    )
+    scheduled_for: date | None = Field(
+        default=None, description="Defaults to the user's current date"
+    )
+    reasoning: Annotated[str | None, Field(max_length=MAX_AUTHORING_TEXT_LENGTH)] = None
+    style_notes: Annotated[str | None, Field(max_length=MAX_AUTHORING_TEXT_LENGTH)] = None
+
+
+@router.post("/item/{item_id}", response_model=PairingResponse, status_code=status.HTTP_201_CREATED)
+async def create_external_pairing(
+    item_id: UUID,
+    request: PairingCreateRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> PairingResponse:
+    """Persist an externally-authored pairing; available regardless of the AI flags."""
+    await rate_limit_by_user(
+        str(current_user.id), "external_pairing", max_requests=20, window_seconds=60
+    )
+
+    source_item = await PairingService(db).get_source_item(current_user.id, item_id)
+    if not source_item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Source item not found or not available",
+        )
+
+    service = ExternalOutfitService(db)
+    try:
+        outfit = await service.create_pairing(
+            user=current_user,
+            source_item_id=item_id,
+            item_ids=request.items,
+            scheduled_for=request.scheduled_for,
+            reasoning=request.reasoning,
+            style_notes=request.style_notes,
+            season=request.season,
+            formality=request.formality,
+            palette=request.palette,
+            notes=request.notes,
+        )
+    except ItemOwnershipError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error_code": "OUTFIT_ITEM_OWNERSHIP",
+                "message": "One or more items do not belong to you",
+            },
+        ) from None
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from None
+
+    await db.commit()
+
+    full = await service.get_full_outfit(outfit.id)
+    return pairing_to_response(full)
+
+
 @router.delete("/{pairing_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_pairing(
     pairing_id: UUID,
@@ -316,7 +395,7 @@ async def delete_pairing(
         and_(
             Outfit.id == pairing_id,
             Outfit.user_id == current_user.id,
-            Outfit.source == OutfitSource.pairing,
+            PAIRING_SOURCE_CLAUSE,
         )
     )
 

--- a/backend/app/models/outfit.py
+++ b/backend/app/models/outfit.py
@@ -39,6 +39,7 @@ class OutfitSource(enum.StrEnum):
     on_demand = "on_demand"
     manual = "manual"
     pairing = "pairing"
+    external = "external"
 
 
 class Outfit(Base):
@@ -58,6 +59,12 @@ class Outfit(Base):
     reasoning: Mapped[str | None] = mapped_column(Text)
     style_notes: Mapped[str | None] = mapped_column(Text)
     ai_raw_response: Mapped[dict | None] = mapped_column(JSONB)
+
+    # Authoring attributes
+    season: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    formality: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    palette: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Status
     status: Mapped[OutfitStatus] = mapped_column(

--- a/backend/app/schemas/outfit.py
+++ b/backend/app/schemas/outfit.py
@@ -1,0 +1,40 @@
+from typing import Annotated
+
+from pydantic import BaseModel, Field, field_validator
+
+MAX_AUTHORING_TEXT_LENGTH = 2000
+
+
+class OutfitAttributeFields(BaseModel):
+    """Optional descriptive outfit attributes shared by the authoring and studio
+    request schemas. Free-form, but canonically match the item tag vocabulary
+    (season: spring/summer/fall/winter/all-season; formality: very-casual
+    through very-formal).
+    """
+
+    season: Annotated[str | None, Field(max_length=20)] = None
+    formality: Annotated[str | None, Field(max_length=50)] = None
+    palette: list[str] | None = Field(
+        default=None,
+        max_length=10,
+        description="Dominant outfit colors, most prominent first",
+    )
+    notes: Annotated[str | None, Field(max_length=MAX_AUTHORING_TEXT_LENGTH)] = None
+
+    @field_validator("season", "formality")
+    @classmethod
+    def normalize_label(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return v.strip().lower() or None
+
+    @field_validator("palette")
+    @classmethod
+    def validate_palette(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        colors = [c.strip().lower() for c in v]
+        if any(not c or len(c) > 50 for c in colors):
+            raise ValueError("Palette colors must be 1-50 characters")
+        # [] collapses to None so "no palette" has a single representation
+        return colors or None

--- a/backend/app/services/external_outfit_service.py
+++ b/backend/app/services/external_outfit_service.py
@@ -1,0 +1,149 @@
+"""Write surface for externally-authored outfits (suggestions and pairings).
+
+Authored rows are regular outfits with source='external'; no separate table.
+"""
+
+from datetime import date
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.outfit import (
+    FamilyOutfitRating,
+    Outfit,
+    OutfitItem,
+    OutfitSource,
+    OutfitStatus,
+)
+from app.models.user import User
+from app.services.studio_service import validate_item_ownership
+from app.utils.timezone import get_user_today
+
+
+class ExternalOutfitService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_full_outfit(self, outfit_id: UUID) -> Outfit:
+        result = await self.db.execute(
+            select(Outfit)
+            .where(Outfit.id == outfit_id)
+            .options(
+                selectinload(Outfit.items).selectinload(OutfitItem.item),
+                selectinload(Outfit.feedback),
+                selectinload(Outfit.source_item),
+                selectinload(Outfit.family_ratings).selectinload(FamilyOutfitRating.user),
+            )
+        )
+        return result.scalar_one()
+
+    async def _persist_outfit(
+        self,
+        user: User,
+        *,
+        ordered_item_ids: list[UUID],
+        occasion: str,
+        name: str | None = None,
+        scheduled_for: date | None,
+        source_item_id: UUID | None = None,
+        reasoning: str | None,
+        style_notes: str | None,
+        season: str | None,
+        formality: str | None,
+        palette: list[str] | None,
+        notes: str | None,
+    ) -> Outfit:
+        await validate_item_ownership(self.db, user.id, ordered_item_ids)
+
+        outfit = Outfit(
+            user_id=user.id,
+            occasion=occasion,
+            scheduled_for=scheduled_for or get_user_today(user),
+            source=OutfitSource.external,
+            status=OutfitStatus.pending,
+            name=name,
+            source_item_id=source_item_id,
+            reasoning=reasoning,
+            style_notes=style_notes,
+            season=season,
+            formality=formality,
+            palette=palette,
+            notes=notes,
+        )
+        self.db.add(outfit)
+        await self.db.flush()
+
+        for position, item_id in enumerate(ordered_item_ids):
+            self.db.add(OutfitItem(outfit_id=outfit.id, item_id=item_id, position=position))
+
+        await self.db.flush()
+        return outfit
+
+    async def create_suggestion(
+        self,
+        user: User,
+        *,
+        item_ids: list[UUID],
+        occasion: str,
+        name: str | None = None,
+        scheduled_for: date | None = None,
+        reasoning: str | None = None,
+        style_notes: str | None = None,
+        season: str | None = None,
+        formality: str | None = None,
+        palette: list[str] | None = None,
+        notes: str | None = None,
+    ) -> Outfit:
+        """Persist an authored suggestion; item positions follow the request order."""
+        return await self._persist_outfit(
+            user,
+            ordered_item_ids=list(dict.fromkeys(item_ids)),
+            occasion=occasion,
+            name=name,
+            scheduled_for=scheduled_for,
+            reasoning=reasoning,
+            style_notes=style_notes,
+            season=season,
+            formality=formality,
+            palette=palette,
+            notes=notes,
+        )
+
+    async def create_pairing(
+        self,
+        user: User,
+        *,
+        source_item_id: UUID,
+        item_ids: list[UUID],
+        scheduled_for: date | None = None,
+        reasoning: str | None = None,
+        style_notes: str | None = None,
+        season: str | None = None,
+        formality: str | None = None,
+        palette: list[str] | None = None,
+        notes: str | None = None,
+    ) -> Outfit:
+        """Persist an authored pairing; the source item leads when absent from item_ids."""
+        ordered = (
+            list(dict.fromkeys(item_ids))
+            if source_item_id in item_ids
+            else list(dict.fromkeys([source_item_id, *item_ids]))
+        )
+        if len(ordered) < 2:
+            raise ValueError("A pairing needs at least one partner item")
+
+        return await self._persist_outfit(
+            user,
+            ordered_item_ids=ordered,
+            occasion="pairing",
+            scheduled_for=scheduled_for,
+            source_item_id=source_item_id,
+            reasoning=reasoning,
+            style_notes=style_notes,
+            season=season,
+            formality=formality,
+            palette=palette,
+            notes=notes,
+        )

--- a/backend/app/services/external_outfit_service.py
+++ b/backend/app/services/external_outfit_service.py
@@ -6,20 +6,12 @@ Authored rows are regular outfits with source='external'; no separate table.
 from datetime import date
 from uuid import UUID
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
-from app.models.outfit import (
-    FamilyOutfitRating,
-    Outfit,
-    OutfitItem,
-    OutfitSource,
-    OutfitStatus,
-)
+from app.models.outfit import Outfit, OutfitItem, OutfitSource, OutfitStatus
 from app.models.user import User
 from app.services.pairing_service import PAIRING_OCCASION
-from app.services.studio_service import validate_item_ownership
+from app.services.studio_service import load_full_outfit, validate_item_ownership
 from app.utils.timezone import get_user_today
 
 
@@ -28,17 +20,7 @@ class ExternalOutfitService:
         self.db = db
 
     async def get_full_outfit(self, outfit_id: UUID) -> Outfit:
-        result = await self.db.execute(
-            select(Outfit)
-            .where(Outfit.id == outfit_id)
-            .options(
-                selectinload(Outfit.items).selectinload(OutfitItem.item),
-                selectinload(Outfit.feedback),
-                selectinload(Outfit.source_item),
-                selectinload(Outfit.family_ratings).selectinload(FamilyOutfitRating.user),
-            )
-        )
-        return result.scalar_one()
+        return await load_full_outfit(self.db, outfit_id)
 
     async def _persist_outfit(
         self,

--- a/backend/app/services/external_outfit_service.py
+++ b/backend/app/services/external_outfit_service.py
@@ -18,6 +18,7 @@ from app.models.outfit import (
     OutfitStatus,
 )
 from app.models.user import User
+from app.services.pairing_service import PAIRING_OCCASION
 from app.services.studio_service import validate_item_ownership
 from app.utils.timezone import get_user_today
 
@@ -137,7 +138,7 @@ class ExternalOutfitService:
         return await self._persist_outfit(
             user,
             ordered_item_ids=ordered,
-            occasion="pairing",
+            occasion=PAIRING_OCCASION,
             scheduled_for=scheduled_for,
             source_item_id=source_item_id,
             reasoning=reasoning,

--- a/backend/app/services/pairing_service.py
+++ b/backend/app/services/pairing_service.py
@@ -19,12 +19,16 @@ logger = logging.getLogger(__name__)
 
 PAIRING_PROMPT_TEMPLATE = load_prompt("item_pairing")
 
-# A pairing is an internally-generated row, or an externally-authored one still
-# anchored to its source item (external rows without one are suggestions).
-# Internal rows stay pairings even after their source item is deleted (SET NULL).
+# A pairing is an internally-generated row, or an externally-authored one carrying the
+# server-set "pairing" occasion (external rows with any other occasion are suggestions).
+# Keyed on occasion rather than source_item_id because that column is ON DELETE SET NULL:
+# hard-deleting the source item must not silently reclassify the row as a suggestion.
+# "pairing" is absent from VALID_OCCASIONS, so an authoring client cannot forge it.
+PAIRING_OCCASION = "pairing"
+
 PAIRING_SOURCE_CLAUSE = or_(
     Outfit.source == OutfitSource.pairing,
-    and_(Outfit.source == OutfitSource.external, Outfit.source_item_id.is_not(None)),
+    and_(Outfit.source == OutfitSource.external, Outfit.occasion == PAIRING_OCCASION),
 )
 
 
@@ -271,7 +275,7 @@ class PairingService:
             # Create outfit
             outfit = Outfit(
                 user_id=user.id,
-                occasion="pairing",
+                occasion=PAIRING_OCCASION,
                 scheduled_for=user_today,
                 source=OutfitSource.pairing,
                 source_item_id=source_item_id,

--- a/backend/app/services/pairing_service.py
+++ b/backend/app/services/pairing_service.py
@@ -3,7 +3,7 @@ import logging
 import re
 from uuid import UUID
 
-from sqlalchemy import and_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -18,6 +18,14 @@ from app.utils.timezone import get_user_today
 logger = logging.getLogger(__name__)
 
 PAIRING_PROMPT_TEMPLATE = load_prompt("item_pairing")
+
+# A pairing is an internally-generated row, or an externally-authored one still
+# anchored to its source item (external rows without one are suggestions).
+# Internal rows stay pairings even after their source item is deleted (SET NULL).
+PAIRING_SOURCE_CLAUSE = or_(
+    Outfit.source == OutfitSource.pairing,
+    and_(Outfit.source == OutfitSource.external, Outfit.source_item_id.is_not(None)),
+)
 
 
 class PairingService:
@@ -317,7 +325,7 @@ class PairingService:
         base_query = select(Outfit).where(
             and_(
                 Outfit.user_id == user_id,
-                Outfit.source == OutfitSource.pairing,
+                PAIRING_SOURCE_CLAUSE,
                 Outfit.source_item_id == source_item_id,
             )
         )
@@ -327,7 +335,7 @@ class PairingService:
             select(Outfit.id).where(
                 and_(
                     Outfit.user_id == user_id,
-                    Outfit.source == OutfitSource.pairing,
+                    PAIRING_SOURCE_CLAUSE,
                     Outfit.source_item_id == source_item_id,
                 )
             )
@@ -362,7 +370,7 @@ class PairingService:
         # Base conditions
         conditions = [
             Outfit.user_id == user_id,
-            Outfit.source == OutfitSource.pairing,
+            PAIRING_SOURCE_CLAUSE,
         ]
 
         # Filter by source item type if specified

--- a/backend/app/services/studio_service.py
+++ b/backend/app/services/studio_service.py
@@ -33,33 +33,34 @@ class OutfitNotTemplateError(Exception):
     pass
 
 
+async def validate_item_ownership(
+    db: AsyncSession, user_id: UUID, item_ids: list[UUID]
+) -> list[ClothingItem]:
+    if not item_ids:
+        raise ValueError("items required")
+
+    result = await db.execute(
+        select(ClothingItem).where(
+            and_(
+                ClothingItem.id.in_(item_ids),
+                ClothingItem.user_id == user_id,
+                ClothingItem.status == ItemStatus.ready,
+            )
+        )
+    )
+    items = list(result.scalars().all())
+    unique_requested = set(item_ids)
+    if len(items) != len(unique_requested):
+        raise ItemOwnershipError("one or more items do not belong to the caller")
+    return items
+
+
 class StudioService:
     CLONE_SOFT_IDEMPOTENCY_SECONDS = 5
 
     def __init__(self, db: AsyncSession):
         self.db = db
         self.learning = LearningService(db)
-
-    async def _validate_item_ownership(
-        self, user_id: UUID, item_ids: list[UUID]
-    ) -> list[ClothingItem]:
-        if not item_ids:
-            raise ValueError("items required")
-
-        result = await self.db.execute(
-            select(ClothingItem).where(
-                and_(
-                    ClothingItem.id.in_(item_ids),
-                    ClothingItem.user_id == user_id,
-                    ClothingItem.status == ItemStatus.ready,
-                )
-            )
-        )
-        items = list(result.scalars().all())
-        unique_requested = set(item_ids)
-        if len(items) != len(unique_requested):
-            raise ItemOwnershipError("one or more items do not belong to the caller")
-        return items
 
     def _order_items_canonically(self, items: list[ClothingItem]) -> list[ClothingItem]:
         type_map = {item.id: (item.type or "") for item in items}
@@ -141,7 +142,7 @@ class StudioService:
         mark_worn: bool,
         source_item_id: UUID | None,
     ) -> Outfit:
-        items = await self._validate_item_ownership(user.id, item_ids)
+        items = await validate_item_ownership(self.db, user.id, item_ids)
         ordered = self._order_items_canonically(items)
 
         effective_worn = scheduled_for if mark_worn else None
@@ -203,7 +204,7 @@ class StudioService:
         if existing_replacement is not None:
             return existing_replacement
 
-        items = await self._validate_item_ownership(user.id, item_ids)
+        items = await validate_item_ownership(self.db, user.id, item_ids)
         ordered = self._order_items_canonically(items)
 
         effective_date = scheduled_for or original.scheduled_for
@@ -382,7 +383,7 @@ class StudioService:
             if outfit.feedback is not None and outfit.feedback.worn_at is not None:
                 raise OutfitWornImmutableError("cannot modify items on a worn outfit")
 
-            new_items = await self._validate_item_ownership(user.id, items)
+            new_items = await validate_item_ownership(self.db, user.id, items)
             ordered = self._order_items_canonically(new_items)
 
             old_item_ids = [oi.item_id for oi in outfit.items]

--- a/backend/app/services/studio_service.py
+++ b/backend/app/services/studio_service.py
@@ -33,6 +33,20 @@ class OutfitNotTemplateError(Exception):
     pass
 
 
+async def load_full_outfit(db: AsyncSession, outfit_id: UUID) -> Outfit:
+    result = await db.execute(
+        select(Outfit)
+        .where(Outfit.id == outfit_id)
+        .options(
+            selectinload(Outfit.items).selectinload(OutfitItem.item),
+            selectinload(Outfit.feedback),
+            selectinload(Outfit.source_item),
+            selectinload(Outfit.family_ratings).selectinload(FamilyOutfitRating.user),
+        )
+    )
+    return result.scalar_one()
+
+
 async def validate_item_ownership(
     db: AsyncSession, user_id: UUID, item_ids: list[UUID]
 ) -> list[ClothingItem]:
@@ -121,16 +135,7 @@ class StudioService:
         return result.scalar_one()
 
     async def get_full_outfit(self, outfit_id: UUID) -> Outfit:
-        result = await self.db.execute(
-            select(Outfit)
-            .where(Outfit.id == outfit_id)
-            .options(
-                selectinload(Outfit.items).selectinload(OutfitItem.item),
-                selectinload(Outfit.feedback),
-                selectinload(Outfit.family_ratings).selectinload(FamilyOutfitRating.user),
-            )
-        )
-        return result.scalar_one()
+        return await load_full_outfit(self.db, outfit_id)
 
     async def create_from_scratch(
         self,

--- a/backend/app/services/studio_service.py
+++ b/backend/app/services/studio_service.py
@@ -141,6 +141,10 @@ class StudioService:
         scheduled_for: date | None,
         mark_worn: bool,
         source_item_id: UUID | None,
+        season: str | None = None,
+        formality: str | None = None,
+        palette: list[str] | None = None,
+        notes: str | None = None,
     ) -> Outfit:
         items = await validate_item_ownership(self.db, user.id, item_ids)
         ordered = self._order_items_canonically(items)
@@ -155,6 +159,10 @@ class StudioService:
             status=OutfitStatus.pending,
             name=name,
             source_item_id=source_item_id,
+            season=season,
+            formality=formality,
+            palette=palette,
+            notes=notes,
         )
         self.db.add(outfit)
         await self.db.flush()

--- a/backend/migrations/versions/e5f6a7b8c9d0_add_external_outfit_authoring.py
+++ b/backend/migrations/versions/e5f6a7b8c9d0_add_external_outfit_authoring.py
@@ -1,0 +1,46 @@
+"""Add the external outfit source and authoring attribute columns.
+
+'external' names the write path: outfits authored through the external
+authoring API rather than generated internally, composed in the studio, or
+derived from a pairing request. The backend can attest to the write path, so
+the value carries the same server-derived semantics as the tagging origins.
+
+The four attribute columns (season, formality, palette, notes) let an author
+record the outfit qualities the internal AI keeps implicit in its reasoning.
+All nullable; existing rows and the internal generation paths are unaffected.
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-10 17:40:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision: str = "e5f6a7b8c9d0"
+down_revision: str | None = "d4e5f6a7b8c9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE outfit_source ADD VALUE IF NOT EXISTS 'external'")
+
+    op.add_column("outfits", sa.Column("season", sa.String(length=20), nullable=True))
+    op.add_column("outfits", sa.Column("formality", sa.String(length=50), nullable=True))
+    op.add_column("outfits", sa.Column("palette", JSONB, nullable=True))
+    op.add_column("outfits", sa.Column("notes", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("outfits", "notes")
+    op.drop_column("outfits", "palette")
+    op.drop_column("outfits", "formality")
+    op.drop_column("outfits", "season")
+
+    # Note: Cannot remove enum value in PostgreSQL, so 'external' will remain

--- a/backend/tests/test_capabilities.py
+++ b/backend/tests/test_capabilities.py
@@ -101,8 +101,8 @@ async def test_capabilities_default_on(client: AsyncClient):
     assert data["ai"] == {"vision": True, "text": True}
     assert data["features"] == {
         "external_tagging": True,
-        "external_suggestions": False,
-        "external_pairings": False,
+        "external_suggestions": True,
+        "external_pairings": True,
     }
     assert data["version"] == "1.0.0"
 

--- a/backend/tests/test_external_authoring.py
+++ b/backend/tests/test_external_authoring.py
@@ -455,3 +455,33 @@ async def test_delete_external_pairing(
 
     listed = await client.get("/api/v1/pairings", headers=auth_headers)
     assert pairing_id not in [p["id"] for p in listed.json()["pairings"]]
+
+
+# --- POST /outfits/studio ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_studio_accepts_authoring_attributes(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+
+    resp = await client.post(
+        "/api/v1/outfits/studio",
+        json={
+            "items": [str(shirt.id), str(jeans.id)],
+            "occasion": "casual",
+            "season": "spring",
+            "formality": "casual",
+            "palette": ["green"],
+            "notes": "Studio compose with attributes",
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["source"] == "manual"
+    assert body["season"] == "spring"
+    assert body["formality"] == "casual"
+    assert body["palette"] == ["green"]
+    assert body["notes"] == "Studio compose with attributes"

--- a/backend/tests/test_external_authoring.py
+++ b/backend/tests/test_external_authoring.py
@@ -457,6 +457,68 @@ async def test_delete_external_pairing(
     assert pairing_id not in [p["id"] for p in listed.json()["pairings"]]
 
 
+@pytest.mark.asyncio
+async def test_external_pairing_survives_source_item_deletion(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    # DELETE /items/{id} hard-deletes, and Outfit.source_item_id is ON DELETE SET NULL,
+    # so the row must stay classifiable as a pairing without leaning on source_item_id.
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+    shirt_id, jeans_id = shirt.id, jeans.id
+
+    created = await client.post(
+        f"/api/v1/pairings/item/{shirt_id}",
+        json={"items": [str(jeans_id)]},
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    pairing_id = created.json()["id"]
+
+    removed = await client.delete(f"/api/v1/items/{shirt_id}", headers=auth_headers)
+    assert removed.status_code == 204, removed.text
+
+    listed = await client.get("/api/v1/pairings", headers=auth_headers)
+    assert listed.status_code == 200, listed.text
+    assert pairing_id in [p["id"] for p in listed.json()["pairings"]]
+
+    deleted = await client.delete(f"/api/v1/pairings/{pairing_id}", headers=auth_headers)
+    assert deleted.status_code == 204, deleted.text
+
+
+@pytest.mark.asyncio
+async def test_generated_pairing_survives_source_item_deletion(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+    shirt_id, jeans_id = shirt.id, jeans.id
+    outfit_id = uuid4()
+
+    outfit = Outfit(
+        id=outfit_id,
+        user_id=test_user.id,
+        occasion="pairing",
+        scheduled_for=date.today(),
+        status=OutfitStatus.pending,
+        source=OutfitSource.pairing,
+        source_item_id=shirt_id,
+    )
+    outfit.items.append(OutfitItem(item_id=shirt_id, position=0))
+    outfit.items.append(OutfitItem(item_id=jeans_id, position=1))
+    db_session.add(outfit)
+    await db_session.commit()
+    # The API shares this session in tests; drop the hand-built rows from the identity map so the
+    # request sees what a fresh production session would, rather than OutfitItem objects the
+    # cascade has already deleted underneath it.
+    db_session.expunge_all()
+
+    removed = await client.delete(f"/api/v1/items/{shirt_id}", headers=auth_headers)
+    assert removed.status_code == 204, removed.text
+
+    listed = await client.get("/api/v1/pairings", headers=auth_headers)
+    assert listed.status_code == 200, listed.text
+    assert str(outfit_id) in [p["id"] for p in listed.json()["pairings"]]
+
+
 # --- POST /outfits/studio ----------------------------------------------------
 
 

--- a/backend/tests/test_external_authoring.py
+++ b/backend/tests/test_external_authoring.py
@@ -1,0 +1,457 @@
+"""External outfit authoring: the agent-facing write surface for suggestions
+and pairings (POST /outfits/suggestions, POST /pairings/item/{item_id}).
+
+Covers persistence as Outfit(source=external), ownership enforcement, the
+authoring attributes (season/formality/palette/notes), pairing list/delete
+inclusion, and availability with internal AI off.
+"""
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import Settings
+from app.models.item import ClothingItem, ItemStatus
+from app.models.outfit import Outfit, OutfitItem, OutfitSource, OutfitStatus
+from app.models.user import User
+
+
+def _make_item(user_id, item_type="shirt", **kwargs) -> ClothingItem:
+    return ClothingItem(
+        user_id=user_id,
+        type=item_type,
+        image_path=f"test/{uuid4()}.jpg",
+        status=ItemStatus.ready,
+        **kwargs,
+    )
+
+
+async def _make_wardrobe(
+    db_session: AsyncSession, user: User, types: list[str]
+) -> list[ClothingItem]:
+    items = [_make_item(user.id, item_type=t) for t in types]
+    db_session.add_all(items)
+    await db_session.commit()
+    return items
+
+
+async def _make_foreign_item(db_session: AsyncSession) -> ClothingItem:
+    unique_id = str(uuid4())[:8]
+    other = User(
+        id=uuid4(),
+        external_id=f"other-user-{unique_id}",
+        email=f"other-{unique_id}@example.com",
+        display_name="Other User",
+        timezone="UTC",
+        is_active=True,
+        onboarding_completed=False,
+    )
+    db_session.add(other)
+    await db_session.flush()
+    item = _make_item(other.id)
+    db_session.add(item)
+    await db_session.commit()
+    return item
+
+
+# --- POST /outfits/suggestions ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_suggestion_persists_external_outfit(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    shirt, jeans, sneakers = await _make_wardrobe(
+        db_session, test_user, ["shirt", "jeans", "sneakers"]
+    )
+
+    resp = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={
+            "items": [str(sneakers.id), str(shirt.id), str(jeans.id)],
+            "occasion": "casual",
+            "name": "Weekend look",
+            "reasoning": "Light layers for a mild day",
+            "style_notes": "Roll the sleeves",
+            "season": "Summer",
+            "formality": "casual",
+            "palette": ["Navy", " white "],
+            "notes": "Pairs well with the canvas tote",
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["source"] == "external"
+    assert body["status"] == "pending"
+    assert body["occasion"] == "casual"
+    assert body["name"] == "Weekend look"
+    assert body["reasoning"] == "Light layers for a mild day"
+    assert body["style_notes"] == "Roll the sleeves"
+    assert body["season"] == "summer"
+    assert body["formality"] == "casual"
+    assert body["palette"] == ["navy", "white"]
+    assert body["notes"] == "Pairs well with the canvas tote"
+    assert body["scheduled_for"] is not None
+    # Positions follow the request order
+    assert [i["id"] for i in body["items"]] == [str(sneakers.id), str(shirt.id), str(jeans.id)]
+
+
+@pytest.mark.asyncio
+async def test_create_suggestion_defaults_attributes_to_null(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+
+    resp = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={"items": [str(shirt.id), str(jeans.id)], "occasion": "office", "palette": []},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["season"] is None
+    assert body["formality"] is None
+    # palette=[] collapses to null
+    assert body["palette"] is None
+    assert body["notes"] is None
+    assert body["name"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_suggestion_accepts_explicit_scheduled_for(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+
+    resp = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={
+            "items": [str(shirt.id), str(jeans.id)],
+            "occasion": "casual",
+            "scheduled_for": "2026-08-01",
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["scheduled_for"] == "2026-08-01"
+
+
+@pytest.mark.asyncio
+async def test_create_suggestion_rejects_foreign_item(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    (shirt,) = await _make_wardrobe(db_session, test_user, ["shirt"])
+    foreign = await _make_foreign_item(db_session)
+
+    resp = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={"items": [str(shirt.id), str(foreign.id)], "occasion": "casual"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["detail"]["error_code"] == "OUTFIT_ITEM_OWNERSHIP"
+
+
+@pytest.mark.asyncio
+async def test_create_suggestion_rejects_invalid_occasion(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    (shirt,) = await _make_wardrobe(db_session, test_user, ["shirt"])
+
+    resp = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={"items": [str(shirt.id)], "occasion": "space-walk"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_suggestion_rejects_unknown_fields(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    (shirt,) = await _make_wardrobe(db_session, test_user, ["shirt"])
+
+    resp = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={"items": [str(shirt.id)], "occasion": "casual", "source": "manual"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_suggestion_validates_attribute_bounds(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    (shirt,) = await _make_wardrobe(db_session, test_user, ["shirt"])
+
+    too_many_colors = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={
+            "items": [str(shirt.id)],
+            "occasion": "casual",
+            "palette": [f"color-{i}" for i in range(11)],
+        },
+        headers=auth_headers,
+    )
+    assert too_many_colors.status_code == 422, too_many_colors.text
+
+    oversized_notes = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={"items": [str(shirt.id)], "occasion": "casual", "notes": "x" * 2001},
+        headers=auth_headers,
+    )
+    assert oversized_notes.status_code == 422, oversized_notes.text
+
+
+@pytest.mark.asyncio
+async def test_create_suggestion_available_with_ai_off(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.services.ai_service.get_settings",
+        lambda: Settings(ai_internal_enabled=False),
+    )
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+
+    resp = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={"items": [str(shirt.id), str(jeans.id)], "occasion": "casual"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["source"] == "external"
+
+
+@pytest.mark.asyncio
+async def test_suggestion_listed_under_external_source_filter(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+
+    created = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={"items": [str(shirt.id), str(jeans.id)], "occasion": "casual"},
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    outfit_id = created.json()["id"]
+
+    listed = await client.get("/api/v1/outfits?source=external", headers=auth_headers)
+    assert listed.status_code == 200, listed.text
+    assert outfit_id in [o["id"] for o in listed.json()["outfits"]]
+
+
+@pytest.mark.asyncio
+async def test_suggestion_not_listed_as_pairing(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+
+    created = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={"items": [str(shirt.id), str(jeans.id)], "occasion": "casual"},
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+
+    pairings = await client.get("/api/v1/pairings", headers=auth_headers)
+    assert pairings.status_code == 200, pairings.text
+    assert created.json()["id"] not in [p["id"] for p in pairings.json()["pairings"]]
+
+
+# --- POST /pairings/item/{item_id} ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_pairing_persists_external_pairing(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    shirt, jeans, jacket = await _make_wardrobe(db_session, test_user, ["shirt", "jeans", "jacket"])
+
+    resp = await client.post(
+        f"/api/v1/pairings/item/{shirt.id}",
+        json={
+            "items": [str(jeans.id), str(jacket.id)],
+            "reasoning": "Denim anchors the shirt",
+            "style_notes": "Keep the jacket open",
+            "season": "fall",
+            "formality": "smart-casual",
+            "palette": ["blue", "grey"],
+            "notes": "Good transitional-weather pick",
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["source"] == "external"
+    assert body["occasion"] == "pairing"
+    assert body["source_item"]["id"] == str(shirt.id)
+    assert body["season"] == "fall"
+    assert body["formality"] == "smart-casual"
+    assert body["palette"] == ["blue", "grey"]
+    assert body["notes"] == "Good transitional-weather pick"
+    # The source item leads when left out of the partner list
+    assert [i["id"] for i in body["items"]] == [str(shirt.id), str(jeans.id), str(jacket.id)]
+
+
+@pytest.mark.asyncio
+async def test_create_pairing_respects_explicit_source_position(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    shirt, jeans, jacket = await _make_wardrobe(db_session, test_user, ["shirt", "jeans", "jacket"])
+
+    resp = await client.post(
+        f"/api/v1/pairings/item/{shirt.id}",
+        json={"items": [str(jeans.id), str(shirt.id), str(jacket.id)]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert [i["id"] for i in body["items"]] == [str(jeans.id), str(shirt.id), str(jacket.id)]
+
+
+@pytest.mark.asyncio
+async def test_create_pairing_unknown_source_item_404(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    (jeans,) = await _make_wardrobe(db_session, test_user, ["jeans"])
+
+    resp = await client.post(
+        f"/api/v1/pairings/item/{uuid4()}",
+        json={"items": [str(jeans.id)]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_pairing_rejects_foreign_partner(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    (shirt,) = await _make_wardrobe(db_session, test_user, ["shirt"])
+    foreign = await _make_foreign_item(db_session)
+
+    resp = await client.post(
+        f"/api/v1/pairings/item/{shirt.id}",
+        json={"items": [str(foreign.id)]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["detail"]["error_code"] == "OUTFIT_ITEM_OWNERSHIP"
+
+
+@pytest.mark.asyncio
+async def test_create_pairing_requires_a_partner(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    (shirt,) = await _make_wardrobe(db_session, test_user, ["shirt"])
+
+    resp = await client.post(
+        f"/api/v1/pairings/item/{shirt.id}",
+        json={"items": [str(shirt.id)]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400, resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_pairing_available_with_ai_off(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.services.ai_service.get_settings",
+        lambda: Settings(ai_internal_enabled=False),
+    )
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+
+    resp = await client.post(
+        f"/api/v1/pairings/item/{shirt.id}",
+        json={"items": [str(jeans.id)]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["source"] == "external"
+
+
+# --- Pairing list/delete inclusion ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_external_pairing_listed_alongside_generated(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+
+    created = await client.post(
+        f"/api/v1/pairings/item/{shirt.id}",
+        json={"items": [str(jeans.id)]},
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    pairing_id = created.json()["id"]
+
+    all_pairings = await client.get("/api/v1/pairings", headers=auth_headers)
+    assert all_pairings.status_code == 200, all_pairings.text
+    assert pairing_id in [p["id"] for p in all_pairings.json()["pairings"]]
+
+    item_pairings = await client.get(f"/api/v1/pairings/item/{shirt.id}", headers=auth_headers)
+    assert item_pairings.status_code == 200, item_pairings.text
+    assert pairing_id in [p["id"] for p in item_pairings.json()["pairings"]]
+
+
+@pytest.mark.asyncio
+async def test_generated_pairing_listing_unchanged(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+
+    outfit = Outfit(
+        user_id=test_user.id,
+        occasion="pairing",
+        scheduled_for=date.today(),
+        status=OutfitStatus.pending,
+        source=OutfitSource.pairing,
+        source_item_id=shirt.id,
+        reasoning="Generated pairing",
+    )
+    outfit.items.append(OutfitItem(item_id=shirt.id, position=0))
+    outfit.items.append(OutfitItem(item_id=jeans.id, position=1))
+    db_session.add(outfit)
+    await db_session.commit()
+
+    listed = await client.get("/api/v1/pairings", headers=auth_headers)
+    assert listed.status_code == 200, listed.text
+    entries = [p for p in listed.json()["pairings"] if p["id"] == str(outfit.id)]
+    assert len(entries) == 1
+    # Default-on regression: internally-generated rows report the attributes as null
+    assert entries[0]["season"] is None
+    assert entries[0]["formality"] is None
+    assert entries[0]["palette"] is None
+    assert entries[0]["notes"] is None
+
+
+@pytest.mark.asyncio
+async def test_delete_external_pairing(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+
+    created = await client.post(
+        f"/api/v1/pairings/item/{shirt.id}",
+        json={"items": [str(jeans.id)]},
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    pairing_id = created.json()["id"]
+
+    deleted = await client.delete(f"/api/v1/pairings/{pairing_id}", headers=auth_headers)
+    assert deleted.status_code == 204, deleted.text
+
+    listed = await client.get("/api/v1/pairings", headers=auth_headers)
+    assert pairing_id not in [p["id"] for p in listed.json()["pairings"]]

--- a/backend/tests/test_external_authoring.py
+++ b/backend/tests/test_external_authoring.py
@@ -519,6 +519,48 @@ async def test_generated_pairing_survives_source_item_deletion(
     assert str(outfit_id) in [p["id"] for p in listed.json()["pairings"]]
 
 
+# --- Suggestion write-path side effects --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_suggestion_clears_cached_suggestions(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession, monkeypatch
+):
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+    cleared: list[tuple] = []
+
+    async def fake_clear(user_id, occasion):
+        cleared.append((user_id, occasion))
+
+    monkeypatch.setattr("app.api.outfits.clear_suggestions", fake_clear)
+
+    resp = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={"items": [str(shirt.id), str(jeans.id)], "occasion": "office"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    assert cleared == [(test_user.id, "office")]
+
+
+@pytest.mark.asyncio
+async def test_create_suggestion_lands_unrated(
+    client: AsyncClient, test_user, auth_headers, db_session: AsyncSession
+):
+    # Unlike the studio path, authoring must not synthesize accepted feedback: the user has not
+    # seen the outfit yet, so learning has nothing to score until they accept or rate it.
+    shirt, jeans = await _make_wardrobe(db_session, test_user, ["shirt", "jeans"])
+
+    resp = await client.post(
+        "/api/v1/outfits/suggestions",
+        json={"items": [str(shirt.id), str(jeans.id)], "occasion": "casual"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["status"] == "pending"
+    assert resp.json()["feedback"] is None
+
+
 # --- POST /outfits/studio ----------------------------------------------------
 
 

--- a/backend/tests/test_studio_service.py
+++ b/backend/tests/test_studio_service.py
@@ -80,6 +80,59 @@ async def test_create_from_scratch(db_session, studio_user, wardrobe_items):
 
 
 @pytest.mark.asyncio
+async def test_create_from_scratch_with_authoring_attributes(
+    db_session, studio_user, wardrobe_items
+):
+    service = StudioService(db_session)
+    shirt, jeans = wardrobe_items[0], wardrobe_items[1]
+
+    outfit = await service.create_from_scratch(
+        user=studio_user,
+        item_ids=[shirt.id, jeans.id],
+        occasion="casual",
+        name=None,
+        scheduled_for=None,
+        mark_worn=False,
+        source_item_id=None,
+        season="summer",
+        formality="smart-casual",
+        palette=["blue", "white"],
+        notes="Composed for the lake trip",
+    )
+    await db_session.commit()
+
+    assert outfit.source == OutfitSource.manual
+    assert outfit.season == "summer"
+    assert outfit.formality == "smart-casual"
+    assert outfit.palette == ["blue", "white"]
+    assert outfit.notes == "Composed for the lake trip"
+
+
+@pytest.mark.asyncio
+async def test_create_from_scratch_leaves_authoring_attributes_unset(
+    db_session, studio_user, wardrobe_items
+):
+    service = StudioService(db_session)
+    shirt, jeans = wardrobe_items[0], wardrobe_items[1]
+
+    outfit = await service.create_from_scratch(
+        user=studio_user,
+        item_ids=[shirt.id, jeans.id],
+        occasion="casual",
+        name=None,
+        scheduled_for=None,
+        mark_worn=False,
+        source_item_id=None,
+    )
+    await db_session.commit()
+
+    assert outfit.season is None
+    assert outfit.formality is None
+    assert outfit.palette is None
+    assert outfit.notes is None
+
+
+@pytest.mark.asyncio
 async def test_create_from_scratch_mark_worn(db_session, studio_user, wardrobe_items):
     service = StudioService(db_session)
     shirt, jeans, sneakers = wardrobe_items[0], wardrobe_items[1], wardrobe_items[2]

--- a/frontend/app/dashboard/family/feed/page.tsx
+++ b/frontend/app/dashboard/family/feed/page.tsx
@@ -12,6 +12,7 @@ import {
   Calendar,
   Zap,
   Edit3,
+  Bot,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -57,6 +58,11 @@ function SourceBadge({ source }: { source: OutfitSource }) {
       icon: Zap,
       label: t('feed.sourceBadges.pairing'),
       className: 'bg-violet-500/10 text-violet-600 border-violet-500/20',
+    },
+    external: {
+      icon: Bot,
+      label: t('feed.sourceBadges.external'),
+      className: 'bg-teal-500/10 text-teal-600 border-teal-500/20',
     },
   };
 

--- a/frontend/components/outfit-calendar.tsx
+++ b/frontend/components/outfit-calendar.tsx
@@ -17,7 +17,8 @@ import {
   addMonths,
   subMonths,
 } from 'date-fns';
-import type { Outfit, OutfitSource } from '@/lib/hooks/use-outfits';
+import type { Outfit } from '@/lib/hooks/use-outfits';
+import { buildCalendarIndicators } from '@/lib/outfits/calendar-indicators';
 import { useTranslations } from 'next-intl';
 
 const WEEKDAY_KEYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const;
@@ -42,19 +43,7 @@ export function OutfitCalendar({
   const t = useTranslations('outfits.calendar');
   const currentMonth = new Date(year, month - 1, 1);
 
-  // Build a map of date -> outfit sources for quick lookup
-  const outfitsByDate = useMemo(() => {
-    const map = new Map<string, Set<OutfitSource>>();
-    outfits.forEach((outfit) => {
-      const dateKey = outfit.scheduled_for;
-      if (!dateKey) return;
-      if (!map.has(dateKey)) {
-        map.set(dateKey, new Set());
-      }
-      map.get(dateKey)!.add(outfit.source);
-    });
-    return map;
-  }, [outfits]);
+  const outfitsByDate = useMemo(() => buildCalendarIndicators(outfits), [outfits]);
 
   // Generate calendar days
   const calendarDays = useMemo(() => {
@@ -109,10 +98,9 @@ export function OutfitCalendar({
       <div className="grid grid-cols-7 gap-1">
         {calendarDays.map((day) => {
           const dateKey = format(day, 'yyyy-MM-dd');
-          const sources = outfitsByDate.get(dateKey);
-          const hasScheduled = sources?.has('scheduled');
-          const hasOnDemand =
-            sources?.has('on_demand') || sources?.has('manual') || sources?.has('external');
+          const indicators = outfitsByDate.get(dateKey);
+          const hasScheduled = indicators?.scheduled;
+          const hasOnDemand = indicators?.onDemand;
           const isSelected = selectedDate && isSameDay(day, selectedDate);
           const isCurrentMonth = isSameMonth(day, currentMonth);
           const isDayToday = isToday(day);
@@ -133,7 +121,7 @@ export function OutfitCalendar({
             >
               <span>{format(day, 'd')}</span>
               {/* Outfit indicators */}
-              {sources && sources.size > 0 && (
+              {(hasScheduled || hasOnDemand) && (
                 <div className="absolute bottom-1 left-1/2 -translate-x-1/2 flex gap-0.5">
                   {hasScheduled && (
                     <span

--- a/frontend/components/outfit-calendar.tsx
+++ b/frontend/components/outfit-calendar.tsx
@@ -111,7 +111,8 @@ export function OutfitCalendar({
           const dateKey = format(day, 'yyyy-MM-dd');
           const sources = outfitsByDate.get(dateKey);
           const hasScheduled = sources?.has('scheduled');
-          const hasOnDemand = sources?.has('on_demand') || sources?.has('manual');
+          const hasOnDemand =
+            sources?.has('on_demand') || sources?.has('manual') || sources?.has('external');
           const isSelected = selectedDate && isSameDay(day, selectedDate);
           const isCurrentMonth = isSameMonth(day, currentMonth);
           const isDayToday = isToday(day);

--- a/frontend/components/outfit-history-card.tsx
+++ b/frontend/components/outfit-history-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { Calendar, Zap, Edit3, ThumbsUp, ThumbsDown, Clock, Eye, Star, ArrowRight, Shirt, Users, ExternalLink } from 'lucide-react';
+import { Calendar, Zap, Edit3, ThumbsUp, ThumbsDown, Clock, Eye, Star, ArrowRight, Shirt, Users, ExternalLink, Bot } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -75,6 +75,11 @@ function SourceBadge({ source }: { source: OutfitSource }) {
       icon: Zap,
       label: t('sourceBadges.pairing'),
       className: 'bg-violet-500/10 text-violet-600 border-violet-500/20',
+    },
+    external: {
+      icon: Bot,
+      label: t('sourceBadges.external'),
+      className: 'bg-teal-500/10 text-teal-600 border-teal-500/20',
     },
   };
 

--- a/frontend/components/outfits/outfit-card.tsx
+++ b/frontend/components/outfits/outfit-card.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import {
   BookmarkCheck,
+  Bot,
   Layers,
   RefreshCw,
   Shirt,
@@ -61,6 +62,13 @@ function getSourceBadge(outfit: Outfit, t: any): {
       label: t('pairing'),
       icon: <Layers className="h-3 w-3" />,
       className: 'bg-amber-100 text-amber-700 border-amber-200',
+    };
+  }
+  if (outfit.source === 'external') {
+    return {
+      label: t('external'),
+      icon: <Bot className="h-3 w-3" />,
+      className: 'bg-teal-100 text-teal-700 border-teal-200',
     };
   }
   return {

--- a/frontend/components/pairing-card.tsx
+++ b/frontend/components/pairing-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Trash2, Star, Sparkles } from 'lucide-react';
+import { Trash2, Star, Sparkles, Bot } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -54,10 +54,21 @@ export function PairingCard({ pairing, onFeedback, onPreview }: PairingCardProps
       <CardContent className="p-3 flex flex-col flex-1">
         {/* Header with source badge */}
         <div className="flex items-center justify-between mb-2">
-          <Badge variant="outline">
-            <Sparkles className="h-3 w-3 mr-1" />
-            {t('badge')}
-          </Badge>
+          <div className="flex items-center gap-1.5">
+            <Badge variant="outline">
+              <Sparkles className="h-3 w-3 mr-1" />
+              {t('badge')}
+            </Badge>
+            {pairing.source === 'external' && (
+              <Badge
+                variant="outline"
+                className="bg-teal-500/10 text-teal-600 border-teal-500/20"
+              >
+                <Bot className="h-3 w-3 mr-1" />
+                {t('externalBadge')}
+              </Badge>
+            )}
+          </div>
           <Button
             variant="ghost"
             size="icon"

--- a/frontend/lib/hooks/use-outfits.ts
+++ b/frontend/lib/hooks/use-outfits.ts
@@ -42,7 +42,7 @@ export interface FeedbackSummary {
   wore_instead_items: WoreInsteadItem[] | null;
 }
 
-export type OutfitSource = 'scheduled' | 'on_demand' | 'manual' | 'pairing';
+export type OutfitSource = 'scheduled' | 'on_demand' | 'manual' | 'pairing' | 'external';
 
 export interface Outfit {
   id: string;

--- a/frontend/lib/hooks/use-outfits.ts
+++ b/frontend/lib/hooks/use-outfits.ts
@@ -55,6 +55,10 @@ export interface Outfit {
   cloned_from_outfit_id: string | null;
   reasoning: string | null;
   style_notes: string | null;
+  season: string | null;
+  formality: string | null;
+  palette: string[] | null;
+  notes: string | null;
   highlights: string[] | null;
   weather: Record<string, unknown> | null;
   items: OutfitItem[];

--- a/frontend/lib/outfits/calendar-indicators.ts
+++ b/frontend/lib/outfits/calendar-indicators.ts
@@ -1,0 +1,31 @@
+import type { Outfit, OutfitSource } from '@/lib/hooks/use-outfits';
+
+const ON_DEMAND_SOURCES: OutfitSource[] = ['on_demand', 'manual', 'external'];
+
+export interface DayIndicators {
+  scheduled: boolean;
+  onDemand: boolean;
+}
+
+// Pairings are anchored to a source item, not to a day; they carry scheduled_for only
+// as a creation artifact, so they must not contribute a day indicator. Keyed on occasion
+// because both internally-generated and externally-authored pairings have to be excluded
+// and they do not share a source value.
+export function buildCalendarIndicators(outfits: Outfit[]): Map<string, DayIndicators> {
+  const map = new Map<string, DayIndicators>();
+
+  outfits.forEach((outfit) => {
+    const dateKey = outfit.scheduled_for;
+    if (!dateKey || outfit.occasion === 'pairing') return;
+
+    const entry = map.get(dateKey) ?? { scheduled: false, onDemand: false };
+    if (outfit.source === 'scheduled') {
+      entry.scheduled = true;
+    } else if (ON_DEMAND_SOURCES.includes(outfit.source)) {
+      entry.onDemand = true;
+    }
+    map.set(dateKey, entry);
+  });
+
+  return map;
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -310,6 +310,10 @@ export interface Outfit {
   source: OutfitSource;
   reasoning?: string;
   style_notes?: string;
+  season?: string | null;
+  formality?: string | null;
+  palette?: string[] | null;
+  notes?: string | null;
   highlights?: string[];
   weather?: WeatherData;
   items: OutfitItem[];

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -300,7 +300,7 @@ export interface FeedbackSummary {
   worn_at?: string;
 }
 
-export type OutfitSource = 'scheduled' | 'on_demand' | 'manual' | 'pairing';
+export type OutfitSource = 'scheduled' | 'on_demand' | 'manual' | 'pairing' | 'external';
 
 export interface Outfit {
   id: string;

--- a/frontend/messages/de/family.json
+++ b/frontend/messages/de/family.json
@@ -30,6 +30,7 @@
     "rateOutfit": "Outfit von {member} bewerten",
     "ratingCount": "({count, plural, one {{count} Bewertung} other {{count} Bewertungen}})",
     "sourceBadges": {
+      "external": "Extern",
       "manual": "Manuell",
       "onDemand": "Auf Anfrage",
       "pairing": "Kombination",

--- a/frontend/messages/de/history.json
+++ b/frontend/messages/de/history.json
@@ -29,6 +29,7 @@
   "noOutfitsForDate": "Keine Outfits für {date}",
   "outfitCount": "{count, plural, one {# Outfit} other {# Outfits}}",
   "sourceBadges": {
+    "external": "Extern",
     "manual": "Manuell",
     "onDemand": "Auf Anfrage",
     "pairing": "Kombination",

--- a/frontend/messages/de/outfits.json
+++ b/frontend/messages/de/outfits.json
@@ -32,6 +32,7 @@
   },
   "cards": {
     "ai": "KI",
+    "external": "Extern",
     "lookbookTemplate": "Lookbook-Vorlage",
     "outfitFallback": "{occasion}-Outfit",
     "pairing": "Kombination",

--- a/frontend/messages/de/pairings.json
+++ b/frontend/messages/de/pairings.json
@@ -5,6 +5,7 @@
     "builtAround": "Aufgebaut um:",
     "deleteError": "Kombination konnte nicht gelöscht werden",
     "deleted": "Kombination gelöscht",
+    "externalBadge": "Extern",
     "rateThisPairing": "Diese Kombination bewerten",
     "tip": "Tipp:",
     "updateRating": "Bewertung aktualisieren"

--- a/frontend/messages/en/family.json
+++ b/frontend/messages/en/family.json
@@ -30,6 +30,7 @@
     "rateOutfit": "Rate {member}'s outfit",
     "ratingCount": "({count, plural, one {{count} rating} other {{count} ratings}})",
     "sourceBadges": {
+      "external": "External",
       "manual": "Manual",
       "onDemand": "On Demand",
       "pairing": "Pairing",

--- a/frontend/messages/en/history.json
+++ b/frontend/messages/en/history.json
@@ -29,6 +29,7 @@
   "noOutfitsForDate": "No outfits for {date}",
   "outfitCount": "{count, plural, one {# outfit} other {# outfits}}",
   "sourceBadges": {
+    "external": "External",
     "manual": "Manual",
     "onDemand": "On Demand",
     "pairing": "Pairing",

--- a/frontend/messages/en/outfits.json
+++ b/frontend/messages/en/outfits.json
@@ -32,6 +32,7 @@
   },
   "cards": {
     "ai": "AI",
+    "external": "External",
     "lookbookTemplate": "Lookbook template",
     "outfitFallback": "{occasion} outfit",
     "pairing": "Pairing",

--- a/frontend/messages/en/pairings.json
+++ b/frontend/messages/en/pairings.json
@@ -5,6 +5,7 @@
     "builtAround": "Built around:",
     "deleteError": "Failed to delete pairing",
     "deleted": "Pairing deleted",
+    "externalBadge": "External",
     "rateThisPairing": "Rate This Pairing",
     "tip": "Tip:",
     "updateRating": "Update Rating"

--- a/frontend/messages/fr/family.json
+++ b/frontend/messages/fr/family.json
@@ -30,6 +30,7 @@
     "rateOutfit": "Noter la tenue de {member}",
     "ratingCount": "({count, plural, one {{count} note} other {{count} notes}})",
     "sourceBadges": {
+      "external": "Externe",
       "manual": "Manuel",
       "onDemand": "À la demande",
       "pairing": "Combinaison",

--- a/frontend/messages/fr/history.json
+++ b/frontend/messages/fr/history.json
@@ -29,6 +29,7 @@
   "noOutfitsForDate": "Aucune tenue pour le {date}",
   "outfitCount": "{count, plural, one {# tenue} other {# tenues}}",
   "sourceBadges": {
+    "external": "Externe",
     "manual": "Manuel",
     "onDemand": "À la demande",
     "pairing": "Combinaison",

--- a/frontend/messages/fr/outfits.json
+++ b/frontend/messages/fr/outfits.json
@@ -32,6 +32,7 @@
   },
   "cards": {
     "ai": "IA",
+    "external": "Externe",
     "lookbookTemplate": "Modèle de lookbook",
     "outfitFallback": "Tenue {occasion}",
     "pairing": "Association",

--- a/frontend/messages/fr/pairings.json
+++ b/frontend/messages/fr/pairings.json
@@ -5,6 +5,7 @@
     "builtAround": "Construit autour de :",
     "deleteError": "Échec de la suppression de la combinaison",
     "deleted": "Combinaison supprimée",
+    "externalBadge": "Externe",
     "rateThisPairing": "Noter cette combinaison",
     "tip": "Conseil :",
     "updateRating": "Mettre à jour la note"

--- a/frontend/messages/it/family.json
+++ b/frontend/messages/it/family.json
@@ -30,6 +30,7 @@
     "rateOutfit": "Valuta l'outfit di {member}",
     "ratingCount": "({count, plural, one {{count} valutazione} other {{count} valutazioni}})",
     "sourceBadges": {
+      "external": "Esterno",
       "manual": "Manuale",
       "onDemand": "Su richiesta",
       "pairing": "Abbinamento",

--- a/frontend/messages/it/history.json
+++ b/frontend/messages/it/history.json
@@ -29,6 +29,7 @@
   "noOutfitsForDate": "Nessun outfit per {date}",
   "outfitCount": "{count, plural, one {# outfit} other {# outfit}}",
   "sourceBadges": {
+    "external": "Esterno",
     "manual": "Manuale",
     "onDemand": "Su richiesta",
     "pairing": "Abbinamento",

--- a/frontend/messages/it/outfits.json
+++ b/frontend/messages/it/outfits.json
@@ -32,6 +32,7 @@
   },
   "cards": {
     "ai": "IA",
+    "external": "Esterno",
     "lookbookTemplate": "Modello lookbook",
     "outfitFallback": "Outfit {occasion}",
     "pairing": "Abbinamento",

--- a/frontend/messages/it/pairings.json
+++ b/frontend/messages/it/pairings.json
@@ -5,6 +5,7 @@
     "builtAround": "Costruito attorno a:",
     "deleteError": "Eliminazione abbinamento fallita",
     "deleted": "Abbinamento eliminato",
+    "externalBadge": "Esterno",
     "rateThisPairing": "Valuta questo abbinamento",
     "tip": "Suggerimento:",
     "updateRating": "Aggiorna valutazione"

--- a/frontend/messages/ja/family.json
+++ b/frontend/messages/ja/family.json
@@ -30,6 +30,7 @@
     "rateOutfit": "{member}のコーデを評価",
     "ratingCount": "（{count, plural, one {{count} 件の評価} other {{count} 件の評価}}）",
     "sourceBadges": {
+      "external": "外部",
       "manual": "手動",
       "onDemand": "オンデマンド",
       "pairing": "ペアリング",

--- a/frontend/messages/ja/history.json
+++ b/frontend/messages/ja/history.json
@@ -29,6 +29,7 @@
   "noOutfitsForDate": "{date}にコーデはありません",
   "outfitCount": "{count, plural, one {# 件のコーデ} other {# 件のコーデ}}",
   "sourceBadges": {
+    "external": "外部",
     "manual": "手動",
     "onDemand": "オンデマンド",
     "pairing": "ペアリング",

--- a/frontend/messages/ja/outfits.json
+++ b/frontend/messages/ja/outfits.json
@@ -32,6 +32,7 @@
   },
   "cards": {
     "ai": "AI",
+    "external": "外部",
     "lookbookTemplate": "ルックブック",
     "outfitFallback": "{occasion}コーデ",
     "pairing": "ペアリング",

--- a/frontend/messages/ja/pairings.json
+++ b/frontend/messages/ja/pairings.json
@@ -5,6 +5,7 @@
     "builtAround": "中心アイテム：",
     "deleteError": "ペアリングの削除に失敗しました",
     "deleted": "ペアリングを削除しました",
+    "externalBadge": "外部",
     "rateThisPairing": "このペアリングを評価",
     "tip": "ヒント：",
     "updateRating": "評価を更新"

--- a/frontend/messages/ko/family.json
+++ b/frontend/messages/ko/family.json
@@ -30,6 +30,7 @@
     "rateOutfit": "{member}의 코디 평가하기",
     "ratingCount": "({count, plural, other {평가 {count}개}})",
     "sourceBadges": {
+      "external": "외부",
       "manual": "수동",
       "onDemand": "즉시",
       "pairing": "페어링",

--- a/frontend/messages/ko/history.json
+++ b/frontend/messages/ko/history.json
@@ -29,6 +29,7 @@
   "noOutfitsForDate": "{date}에 코디가 없어요",
   "outfitCount": "{count, plural, other {코디 #개}}",
   "sourceBadges": {
+    "external": "외부",
     "manual": "수동",
     "onDemand": "즉시",
     "pairing": "페어링",

--- a/frontend/messages/ko/outfits.json
+++ b/frontend/messages/ko/outfits.json
@@ -32,6 +32,7 @@
   },
   "cards": {
     "ai": "AI",
+    "external": "외부",
     "lookbookTemplate": "룩북 템플릿",
     "outfitFallback": "{occasion} 코디",
     "pairing": "페어링",

--- a/frontend/messages/ko/pairings.json
+++ b/frontend/messages/ko/pairings.json
@@ -5,6 +5,7 @@
     "builtAround": "중심 아이템:",
     "deleteError": "페어링 삭제 실패",
     "deleted": "페어링이 삭제되었어요",
+    "externalBadge": "외부",
     "rateThisPairing": "이 페어링 평가하기",
     "tip": "팁:",
     "updateRating": "평점 수정"

--- a/frontend/messages/zh-CN/family.json
+++ b/frontend/messages/zh-CN/family.json
@@ -30,6 +30,7 @@
     "rateOutfit": "为 {member} 的穿搭评分",
     "ratingCount": "（{count, plural, one {{count} 条评分} other {{count} 条评分}}）",
     "sourceBadges": {
+      "external": "外部",
       "manual": "手动",
       "onDemand": "即时获取",
       "pairing": "搭配",

--- a/frontend/messages/zh-CN/history.json
+++ b/frontend/messages/zh-CN/history.json
@@ -29,6 +29,7 @@
   "noOutfitsForDate": "{date}没有穿搭",
   "outfitCount": "{count, plural, one {# 套穿搭} other {# 套穿搭}}",
   "sourceBadges": {
+    "external": "外部",
     "manual": "手动",
     "onDemand": "即时获取",
     "pairing": "搭配",

--- a/frontend/messages/zh-CN/outfits.json
+++ b/frontend/messages/zh-CN/outfits.json
@@ -32,6 +32,7 @@
   },
   "cards": {
     "ai": "AI",
+    "external": "外部",
     "lookbookTemplate": "造型册模板",
     "outfitFallback": "{occasion}搭配",
     "pairing": "搭配",

--- a/frontend/messages/zh-CN/pairings.json
+++ b/frontend/messages/zh-CN/pairings.json
@@ -5,6 +5,7 @@
     "builtAround": "核心单品：",
     "deleteError": "删除搭配失败",
     "deleted": "搭配已删除",
+    "externalBadge": "外部",
     "rateThisPairing": "评价这组搭配",
     "tip": "小贴士：",
     "updateRating": "更新评分"

--- a/frontend/messages/zh-TW/family.json
+++ b/frontend/messages/zh-TW/family.json
@@ -30,6 +30,7 @@
     "rateOutfit": "為 {member} 的穿搭評分",
     "ratingCount": "（{count, plural, one {{count} 則評分} other {{count} 則評分}}）",
     "sourceBadges": {
+      "external": "外部",
       "manual": "手動",
       "onDemand": "隨選",
       "pairing": "配對",

--- a/frontend/messages/zh-TW/history.json
+++ b/frontend/messages/zh-TW/history.json
@@ -29,6 +29,7 @@
   "noOutfitsForDate": "{date} 沒有穿搭",
   "outfitCount": "{count, plural, one {# 套穿搭} other {# 套穿搭}}",
   "sourceBadges": {
+    "external": "外部",
     "manual": "手動",
     "onDemand": "隨選",
     "pairing": "配對",

--- a/frontend/messages/zh-TW/outfits.json
+++ b/frontend/messages/zh-TW/outfits.json
@@ -32,6 +32,7 @@
   },
   "cards": {
     "ai": "AI",
+    "external": "外部",
     "lookbookTemplate": "造型冊範本",
     "outfitFallback": "{occasion} 穿搭",
     "pairing": "搭配",

--- a/frontend/messages/zh-TW/pairings.json
+++ b/frontend/messages/zh-TW/pairings.json
@@ -5,6 +5,7 @@
     "builtAround": "核心單品：",
     "deleteError": "刪除配對失敗",
     "deleted": "配對已刪除",
+    "externalBadge": "外部",
     "rateThisPairing": "為此配對評分",
     "tip": "提示：",
     "updateRating": "更新評分"

--- a/frontend/tests/calendar-indicators.test.ts
+++ b/frontend/tests/calendar-indicators.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCalendarIndicators } from '@/lib/outfits/calendar-indicators';
+import type { Outfit, OutfitSource } from '@/lib/hooks/use-outfits';
+
+function makeOutfit(
+  source: OutfitSource,
+  occasion: string,
+  scheduled_for: string | null,
+): Outfit {
+  return {
+    id: `${source}-${occasion}-${scheduled_for}`,
+    occasion,
+    scheduled_for,
+    status: 'pending',
+    source,
+    name: null,
+    replaces_outfit_id: null,
+    cloned_from_outfit_id: null,
+    reasoning: null,
+    style_notes: null,
+    season: null,
+    formality: null,
+    palette: null,
+    notes: null,
+    highlights: null,
+    weather: null,
+    items: [],
+    feedback: null,
+    family_ratings: null,
+    family_rating_average: null,
+    family_rating_count: null,
+    created_at: '2026-07-30T00:00:00Z',
+  };
+}
+
+describe('buildCalendarIndicators', () => {
+  it('marks scheduled outfits on their day', () => {
+    const map = buildCalendarIndicators([makeOutfit('scheduled', 'casual', '2026-07-30')]);
+    expect(map.get('2026-07-30')).toEqual({ scheduled: true, onDemand: false });
+  });
+
+  it('treats on_demand, manual and external as the on-demand indicator', () => {
+    const map = buildCalendarIndicators([
+      makeOutfit('on_demand', 'casual', '2026-07-30'),
+      makeOutfit('manual', 'office', '2026-07-31'),
+      makeOutfit('external', 'formal', '2026-08-01'),
+    ]);
+    expect(map.get('2026-07-30')?.onDemand).toBe(true);
+    expect(map.get('2026-07-31')?.onDemand).toBe(true);
+    expect(map.get('2026-08-01')?.onDemand).toBe(true);
+  });
+
+  it('excludes externally-authored pairings', () => {
+    const map = buildCalendarIndicators([makeOutfit('external', 'pairing', '2026-07-30')]);
+    expect(map.has('2026-07-30')).toBe(false);
+  });
+
+  it('excludes internally-generated pairings', () => {
+    const map = buildCalendarIndicators([makeOutfit('pairing', 'pairing', '2026-07-30')]);
+    expect(map.has('2026-07-30')).toBe(false);
+  });
+
+  it('keeps a day marked when a pairing shares it with a real suggestion', () => {
+    const map = buildCalendarIndicators([
+      makeOutfit('external', 'pairing', '2026-07-30'),
+      makeOutfit('external', 'casual', '2026-07-30'),
+    ]);
+    expect(map.get('2026-07-30')).toEqual({ scheduled: false, onDemand: true });
+  });
+
+  it('combines both indicators on the same day', () => {
+    const map = buildCalendarIndicators([
+      makeOutfit('scheduled', 'casual', '2026-07-30'),
+      makeOutfit('external', 'office', '2026-07-30'),
+    ]);
+    expect(map.get('2026-07-30')).toEqual({ scheduled: true, onDemand: true });
+  });
+
+  it('skips lookbook entries with no date', () => {
+    const map = buildCalendarIndicators([makeOutfit('manual', 'casual', null)]);
+    expect(map.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

This is phase 3 of making the internal AI optional so the backend can defer generation work to an external agent (e.g. Claude via an MCP server). Phase 1 (#113) added the capability switches and `/capabilities`; phase 2 (#120) made item tagging externally ownable. This phase makes **outfit suggestions and pairings** externally authorable — with internal text generation off, `/outfits/suggest` and `/pairings/generate` 503 by design, and until now there was no write surface for anything else to fill that role.

- **New `external` value on `outfit_source`** — names the write path (authored through the external authoring API), consistent with phase 2's server-derived `auto|manual` origins. Never accepted from a request body.
- **Four nullable authoring attribute columns** on `outfits`: `season`, `formality` (length-capped strings; canonical vocabulary documented in `app/schemas/outfit.py`, matching the item-tag precedent rather than enum enforcement), `palette` (JSONB list of colors, `[]` collapses to null), `notes` (text). Shared across the authoring and studio request schemas via one `OutfitAttributeFields` base. Existing rows and internal generation paths are unaffected.
- **`POST /outfits/suggestions`** persists an authored suggestion: occasion validated against the existing `VALID_OCCASIONS`, item positions follow request order, `scheduled_for` defaults to the user's local today, ownership violations return 403 with `OUTFIT_ITEM_OWNERSHIP`, rate-limited 20/min. Lands as a normal `pending` suggestion the user accepts or rejects in the app.
- **`POST /pairings/item/{item_id}`** persists an authored pairing around a source item: `occasion="pairing"` is set server-side, the source item is auto-prepended when absent from the partner list, unknown source item → 404, no partner items → 400. The route shape mirrors the existing `GET /pairings/item/{item_id}` and reuses `PairingResponse`.
- **Pairing reads and deletes** now match "internally generated, or externally authored around a source item" (`PAIRING_SOURCE_CLAUSE`), so authored pairings appear on the item's pairings page. External rows without a source item are suggestions and stay out; internal pairings whose source item was deleted (SET NULL) remain listed — no regression.
- **`GET /capabilities`** flips `external_suggestions` and `external_pairings` to `true`, per the phase-1 contract (flags flip in the PR that ships the write surface).
- **Studio composer** accepts the same four attributes (separate droppable commit; gated by the existing studio kill switch — the authoring endpoints are not).
- **Frontend**: `external` joins the `OutfitSource` unions and gets a labeled badge in the outfit card, history card, family feed, and pairing card — the existing `Record<OutfitSource, …>` badge maps would throw on the unknown key, and the outfit card would otherwise mislabel agent-authored outfits as "AI". Badge labels go through `next-intl` with entries added to all 8 locale catalogs (`i18n:check` clean). The history calendar counts `external` toward the on-demand indicator dot.

Everything is additive and defaults to current behavior. Suggestion/pairing responses gain the four attribute fields; internally-generated rows report them as null. Phase 1's 503s on `/outfits/suggest` and `/pairings/generate` are unchanged.

## Related Issue

Related to #99; phase 3 of the series (#113, #120)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the project's coding style
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes don't introduce new warnings or errors

## Testing

### Test Environment
- [x] Docker Compose
- [x] Kubernetes
- [x] Local development

### Tests Performed
- New `backend/tests/test_external_authoring.py` (22 tests): suggestion authoring with request-order positions and attribute round-trip; `palette: []` → null; occasion validation; ownership 403; pairing authoring with source auto-prepend and dedup; unknown source 404; missing partner 400; authored pairings included in the item's pairing list and deletable; suggestions (no source item) excluded from pairing reads; internal-row regression (attributes null, listing unchanged); studio attribute passthrough; capabilities flip.
- Full backend suite green (`453 passed`); `ruff check` and `ruff format` clean; migration upgrade and downgrade verified (`e5f6a7b8c9d0`, parented on `d4e5f6a7b8c9`).
- Frontend: `tsc --noEmit` clean; vitest suite green (111 tests); `i18n:check` (keys, parity, scan) clean.
- End-to-end validated against a live Kubernetes deployment (internal AI off) through an MCP client: authored suggestion and pairing with full attribute round-trip, server-set occasion and source-item block, positions in request order, `scheduled_for` defaulting to the user's local date, and the External labeling/calendar indicators rendering on live data.

## Screenshots (if applicable)
<img width="1283" height="891" alt="Screenshot from 2026-07-31 00-33-03" src="https://github.com/user-attachments/assets/03d2e169-a8a6-4ede-8c4f-371e79ffedb6" />

<img width="876" height="734" alt="Screenshot from 2026-07-22 02-02-51" src="https://github.com/user-attachments/assets/ce46a114-37bd-4560-a9dd-6c4e2103cb74" />

<img width="1442" height="842" alt="Screenshot from 2026-07-22 02-02-27" src="https://github.com/user-attachments/assets/c7452986-72a1-449b-af1b-a5d4875a6794" />

## Additional Notes

- **Provenance is server-derived.** `source=external` comes from the write path only; there is no way to claim it from a request body, and no attempt to distinguish an agent from any other API client (same reasoning as phase 2's `auto|manual`).
- **Non-goals**, stated to bound the surface: no demand-signal/request queue for suggestions (the external agent is pull/conversation-driven); no suggestion-cache invalidation on external authoring (no correctness impact); authored outfits do not carry `weather_data` or per-item `layer_type`.
- Internally-generated `pairing` rows have never produced a calendar indicator (they rarely carry `scheduled_for`); that pre-existing behavior is left untouched.
- The branch is organized as six independently reviewable commits: enum + attribute columns + migration → authoring endpoints → capabilities flip → tests → studio extension (droppable) → frontend labeling (droppable).
- The consuming MCP-side changes ship in jansitarski/wardrowbe-mcp#29 (`create_outfit_suggestion`, `create_item_pairing`, attributes on `create_outfit`) and were validated end-to-end against this branch.
