### PR TITLE
fix(recommendation): support all-season items and weather-aware season scoring

### DIFF
--- a/backend/app/services/item_scorer.py
+++ b/backend/app/services/item_scorer.py
@@ -220,12 +220,38 @@ def _formality_score(item: ClothingItem, occasion: str) -> float:
     return 0.15
 
 
-def _season_score(item: ClothingItem, current_season: str) -> float:
+def _season_score(
+    item: ClothingItem,
+    current_season: str,
+    weather: WeatherData | None = None,
+    preferences: UserPreference | None = None,
+) -> float:
     seasons = item.season or []
-    if not seasons:
+    if not seasons or "all-season" in seasons or current_season in seasons:
         return 1.0
-    if current_season in seasons:
-        return 1.0
+
+    if weather is not None:
+        hot_threshold = (
+            preferences.hot_threshold
+            if (preferences and preferences.hot_threshold is not None)
+            else 25
+        )
+        cold_threshold = (
+            preferences.cold_threshold
+            if (preferences and preferences.cold_threshold is not None)
+            else 10
+        )
+        if preferences and preferences.temperature_sensitivity == "high":
+            cold_threshold += 5
+            hot_threshold -= 5
+        elif preferences and preferences.temperature_sensitivity == "low":
+            cold_threshold -= 5
+            hot_threshold += 5
+
+        if weather.temperature >= hot_threshold and "summer" in seasons:
+            return 1.0
+        if weather.temperature <= cold_threshold and "winter" in seasons:
+            return 1.0
 
     adjacent = SEASON_ADJACENCY.get(current_season, [])
     if any(s in adjacent for s in seasons):
@@ -312,6 +338,43 @@ def _sort_mandatory_first(
     return sorted(scored, key=lambda s: s.item.id not in mandatory_item_ids)
 
 
+def _ensure_role_diversity(
+    scored: list[ScoredItem],
+    top_n: int = TOP_N,
+    min_per_role: int = 4,
+    mandatory_item_ids: set[UUID] | None = None,
+) -> list[ScoredItem]:
+    from app.utils.clothing import ITEM_ROLE
+
+    if len(scored) <= top_n:
+        return scored
+
+    mandatory = mandatory_item_ids or set()
+    top = list(scored[:top_n])
+
+    footwear_count = sum(1 for s in top if ITEM_ROLE.get(s.item.type) == "footwear")
+    if footwear_count < min_per_role:
+        remaining_footwear = [
+            s for s in scored[top_n:]
+            if ITEM_ROLE.get(s.item.type) == "footwear"
+        ]
+        needed = min_per_role - footwear_count
+        to_promote = remaining_footwear[:needed]
+        if to_promote:
+            promote_ids = {s.item.id for s in to_promote}
+            candidates_to_drop = [
+                i for i in range(len(top) - 1, -1, -1)
+                if top[i].item.id not in mandatory and top[i].item.id not in promote_ids
+            ]
+            drop_indices = set(candidates_to_drop[: len(to_promote)])
+            new_top = [s for i, s in enumerate(top) if i not in drop_indices] + to_promote
+            new_top.sort(key=lambda s: (s.item.id in mandatory, s.score), reverse=True)
+            remaining = [s for s in scored if s.item.id not in {x.item.id for x in new_top}]
+            return new_top + remaining
+
+    return scored
+
+
 def _pair_bonus(
     item: ClothingItem,
     top_items: list[ClothingItem],
@@ -362,7 +425,7 @@ def score_items(
     for item in items:
         ws = _weather_score(item, weather, preferences)
         fs = _formality_score(item, occasion)
-        ss = _season_score(item, current_season)
+        ss = _season_score(item, current_season, weather, preferences)
         rs = _recency_score(item, user_today, avoid_days, recently_worn_dates)
         ps = _preference_score(item, preferences, learned_prefs)
         us = _usage_score(item, median_wear) if use_underused else 1.0
@@ -392,4 +455,7 @@ def score_items(
 
     scored.sort(key=lambda s: s.score, reverse=True)
     scored = _sort_mandatory_first(scored, mandatory_item_ids)
+    scored = _ensure_role_diversity(
+        scored, TOP_N, min_per_role=4, mandatory_item_ids=mandatory_item_ids
+    )
     return scored[:TOP_N]

--- a/backend/app/services/item_scorer.py
+++ b/backend/app/services/item_scorer.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from app.models.item import ClothingItem
 from app.models.preference import UserPreference
 from app.services.weather_service import WeatherData
+from app.utils.clothing import ITEM_ROLE
 
 OCCASION_FORMALITY = {
     "casual": ["very-casual", "casual", "smart-casual"],
@@ -73,6 +74,15 @@ SEASON_ADJACENCY = {
 
 TOP_N = 70
 MIN_ITEMS_FOR_SCORING = 50
+
+DEFAULT_COLD_THRESHOLD = 10
+DEFAULT_HOT_THRESHOLD = 25
+SENSITIVITY_SHIFT = 5
+
+# An outfit is unwearable without these, so the prompt must keep candidates for them even
+# when a whole category scores below the TOP_N cut and would otherwise be sliced away.
+ESSENTIAL_ROLES = ("footwear", "bottom")
+MIN_CANDIDATES_PER_ESSENTIAL_ROLE = 4
 
 TEMP_RANGE_MIN_SWING = 8.0
 REMOVABLE_LAYER_HOT_FLOOR = 0.6
@@ -151,13 +161,9 @@ def scoring_temp_range(weather: WeatherData) -> tuple[float, float] | None:
     return weather.window_min, weather.window_max
 
 
-def _weather_score(
-    item: ClothingItem,
-    weather: WeatherData,
-    preferences: UserPreference | None,
-) -> float:
-    cold_threshold = 10
-    hot_threshold = 25
+def _resolve_temp_thresholds(preferences: UserPreference | None) -> tuple[float, float]:
+    cold_threshold = DEFAULT_COLD_THRESHOLD
+    hot_threshold = DEFAULT_HOT_THRESHOLD
 
     if preferences:
         if preferences.cold_threshold is not None:
@@ -165,11 +171,21 @@ def _weather_score(
         if preferences.hot_threshold is not None:
             hot_threshold = preferences.hot_threshold
         if preferences.temperature_sensitivity == "high":
-            cold_threshold += 5
-            hot_threshold -= 5
+            cold_threshold += SENSITIVITY_SHIFT
+            hot_threshold -= SENSITIVITY_SHIFT
         elif preferences.temperature_sensitivity == "low":
-            cold_threshold -= 5
-            hot_threshold += 5
+            cold_threshold -= SENSITIVITY_SHIFT
+            hot_threshold += SENSITIVITY_SHIFT
+
+    return cold_threshold, hot_threshold
+
+
+def _weather_score(
+    item: ClothingItem,
+    weather: WeatherData,
+    preferences: UserPreference | None,
+) -> float:
+    cold_threshold, hot_threshold = _resolve_temp_thresholds(preferences)
 
     item_type = (item.type or "").lower()
     material = (item.material or "").lower()
@@ -231,22 +247,7 @@ def _season_score(
         return 1.0
 
     if weather is not None:
-        hot_threshold = (
-            preferences.hot_threshold
-            if (preferences and preferences.hot_threshold is not None)
-            else 25
-        )
-        cold_threshold = (
-            preferences.cold_threshold
-            if (preferences and preferences.cold_threshold is not None)
-            else 10
-        )
-        if preferences and preferences.temperature_sensitivity == "high":
-            cold_threshold += 5
-            hot_threshold -= 5
-        elif preferences and preferences.temperature_sensitivity == "low":
-            cold_threshold -= 5
-            hot_threshold += 5
+        cold_threshold, hot_threshold = _resolve_temp_thresholds(preferences)
 
         if weather.temperature >= hot_threshold and "summer" in seasons:
             return 1.0
@@ -338,41 +339,43 @@ def _sort_mandatory_first(
     return sorted(scored, key=lambda s: s.item.id not in mandatory_item_ids)
 
 
+def _role_of(scored_item: ScoredItem) -> str | None:
+    return ITEM_ROLE.get((scored_item.item.type or "").lower())
+
+
 def _ensure_role_diversity(
     scored: list[ScoredItem],
     top_n: int = TOP_N,
-    min_per_role: int = 4,
+    min_per_role: int = MIN_CANDIDATES_PER_ESSENTIAL_ROLE,
     mandatory_item_ids: set[UUID] | None = None,
 ) -> list[ScoredItem]:
-    from app.utils.clothing import ITEM_ROLE
-
     if len(scored) <= top_n:
         return scored
 
     mandatory = mandatory_item_ids or set()
-    top = list(scored[:top_n])
+    head = scored[:top_n]
+    tail = scored[top_n:]
 
-    footwear_count = sum(1 for s in top if ITEM_ROLE.get(s.item.type) == "footwear")
-    if footwear_count < min_per_role:
-        remaining_footwear = [
-            s for s in scored[top_n:]
-            if ITEM_ROLE.get(s.item.type) == "footwear"
-        ]
-        needed = min_per_role - footwear_count
-        to_promote = remaining_footwear[:needed]
-        if to_promote:
-            promote_ids = {s.item.id for s in to_promote}
-            candidates_to_drop = [
-                i for i in range(len(top) - 1, -1, -1)
-                if top[i].item.id not in mandatory and top[i].item.id not in promote_ids
-            ]
-            drop_indices = set(candidates_to_drop[: len(to_promote)])
-            new_top = [s for i, s in enumerate(top) if i not in drop_indices] + to_promote
-            new_top.sort(key=lambda s: (s.item.id in mandatory, s.score), reverse=True)
-            remaining = [s for s in scored if s.item.id not in {x.item.id for x in new_top}]
-            return new_top + remaining
+    promoted: list[ScoredItem] = []
+    for role in ESSENTIAL_ROLES:
+        missing = min_per_role - sum(1 for s in head if _role_of(s) == role)
+        if missing > 0:
+            promoted.extend([s for s in tail if _role_of(s) == role][:missing])
 
-    return scored
+    if not promoted:
+        return scored
+
+    promoted_ids = {s.item.id for s in promoted}
+    keep = [s for s in head if s.item.id in mandatory]
+    keep_ids = {s.item.id for s in keep}
+    # head is already score-ordered, so taking the front of it drops the weakest entries.
+    room = max(top_n - len(keep) - len(promoted), 0)
+    filler = [s for s in head if s.item.id not in keep_ids and s.item.id not in promoted_ids][:room]
+
+    new_head = keep + filler + promoted
+    new_head.sort(key=lambda s: (s.item.id in mandatory, s.score), reverse=True)
+    new_head_ids = {s.item.id for s in new_head}
+    return new_head + [s for s in scored if s.item.id not in new_head_ids]
 
 
 def _pair_bonus(
@@ -455,7 +458,5 @@ def score_items(
 
     scored.sort(key=lambda s: s.score, reverse=True)
     scored = _sort_mandatory_first(scored, mandatory_item_ids)
-    scored = _ensure_role_diversity(
-        scored, TOP_N, min_per_role=4, mandatory_item_ids=mandatory_item_ids
-    )
+    scored = _ensure_role_diversity(scored, TOP_N, mandatory_item_ids=mandatory_item_ids)
     return scored[:TOP_N]

--- a/backend/tests/test_item_scorer.py
+++ b/backend/tests/test_item_scorer.py
@@ -308,6 +308,28 @@ class TestSeasonScore:
         item = _item(season=[])
         assert _season_score(item, "winter") == 1.0
 
+    def test_all_season(self):
+        item = _item(season=["all-season"])
+        assert _season_score(item, "winter") == 1.0
+        assert _season_score(item, "summer") == 1.0
+        assert _season_score(item, "spring") == 1.0
+        assert _season_score(item, "fall") == 1.0
+
+    def test_summer_item_in_fall_with_hot_weather(self):
+        item = _item(season=["summer"])
+        hot_weather = _weather(temp=28)
+        assert _season_score(item, "fall", hot_weather) == 1.0
+
+    def test_summer_item_in_fall_with_cool_weather(self):
+        item = _item(season=["summer"])
+        cool_weather = _weather(temp=18)
+        assert _season_score(item, "fall", cool_weather) == 0.6
+
+    def test_winter_item_in_spring_with_cold_weather(self):
+        item = _item(season=["winter"])
+        cold_weather = _weather(temp=5)
+        assert _season_score(item, "spring", cold_weather) == 1.0
+
 
 class TestGetSeason:
     def test_northern_hemisphere(self):
@@ -531,3 +553,22 @@ class TestScoreItems:
         shirt_pos = next(i for i, s in enumerate(result) if s.item.id == shirt.id)
         sweater_pos = next(i for i, s in enumerate(result) if s.item.id == sweater.id)
         assert sweater_pos < shirt_pos
+
+    def test_ensures_footwear_represented_in_top_n(self):
+        # 75 shirts (scoring high) + 3 footwear (scoring lower)
+        shirts = [_item(type="shirt") for _ in range(75)]
+        shoes = [_item(type="sneakers") for _ in range(3)]
+        all_items = shirts + shoes
+        result = score_items(
+            items=all_items,
+            weather=_weather(temp=20),
+            occasion="casual",
+            preferences=None,
+            user_today=date(2026, 3, 8),
+            current_season="spring",
+            learned_prefs=None,
+            good_pairs={},
+            recently_worn_dates={},
+        )
+        footwear_in_result = [s for s in result if s.item.type == "sneakers"]
+        assert len(footwear_in_result) == 3

--- a/backend/tests/test_item_scorer.py
+++ b/backend/tests/test_item_scorer.py
@@ -572,3 +572,67 @@ class TestScoreItems:
         )
         footwear_in_result = [s for s in result if s.item.type == "sneakers"]
         assert len(footwear_in_result) == 3
+
+
+class TestSeasonScoreThresholds:
+    def test_high_sensitivity_lowers_the_hot_threshold(self):
+        item = _item(season=["summer"])
+        weather = _weather(temp=21)
+        assert _season_score(item, "fall", weather) == 0.6
+        sensitive = _prefs(temperature_sensitivity="high")
+        assert _season_score(item, "fall", weather, sensitive) == 1.0
+
+    def test_low_sensitivity_raises_the_hot_threshold(self):
+        item = _item(season=["summer"])
+        weather = _weather(temp=27)
+        assert _season_score(item, "fall", weather) == 1.0
+        tolerant = _prefs(temperature_sensitivity="low")
+        assert _season_score(item, "fall", weather, tolerant) == 0.6
+
+    def test_custom_cold_threshold_is_honoured(self):
+        item = _item(season=["winter"])
+        weather = _weather(temp=14)
+        assert _season_score(item, "spring", weather) == 0.6
+        assert _season_score(item, "spring", weather, _prefs(cold_threshold=15)) == 1.0
+
+
+class TestRoleDiversity:
+    def _wardrobe(self, footwear_type="sneakers"):
+        shirts = [_item(type="shirt") for _ in range(75)]
+        bottoms = [_item(type="jeans") for _ in range(3)]
+        shoes = [_item(type=footwear_type) for _ in range(3)]
+        return shirts, bottoms, shoes
+
+    def _score(self, items, **kwargs):
+        return score_items(
+            items=items,
+            weather=_weather(temp=20),
+            occasion="casual",
+            preferences=None,
+            user_today=date(2026, 3, 8),
+            current_season="spring",
+            learned_prefs=None,
+            good_pairs={},
+            recently_worn_dates={},
+            **kwargs,
+        )
+
+    def test_keeps_bottoms_as_well_as_footwear(self):
+        shirts, bottoms, shoes = self._wardrobe()
+        result = self._score(shirts + bottoms + shoes)
+        result_ids = {s.item.id for s in result}
+        assert {b.id for b in bottoms} <= result_ids
+        assert {s.id for s in shoes} <= result_ids
+
+    def test_matches_role_regardless_of_type_casing(self):
+        shirts, bottoms, shoes = self._wardrobe(footwear_type="Sneakers")
+        result = self._score(shirts + bottoms + shoes)
+        assert {s.id for s in shoes} <= {s.item.id for s in result}
+
+    def test_promotion_never_evicts_a_mandatory_item(self):
+        shirts, bottoms, shoes = self._wardrobe()
+        mandatory = shirts[-1]
+        result = self._score(shirts + bottoms + shoes, mandatory_item_ids={mandatory.id})
+        result_ids = {s.item.id for s in result}
+        assert mandatory.id in result_ids
+        assert {s.id for s in shoes} <= result_ids


### PR DESCRIPTION
### Summary
Fixes an issue where items tagged `"all-season"` (such as everyday sneakers, chinos, and basics) and weather-appropriate items (such as shorts on hot days during calendar autumn) received heavy season penalties during pre-ranking, starving the recommendation prompt of footwear and warm-weather bottoms.

### Problem
1. **`all-season` Treated as Off-Season**: When items were auto-tagged by AI vision, sneakers and basics often received `season: ["all-season"]`. In `_season_score()`, the function checked only for direct matches with the calendar season (e.g. `fall` in September) or adjacent seasons (`summer`, `winter`). Because `"all-season"` was not checked, every `all-season` item was treated as completely off-season, receiving an 80% penalty (`0.2` multiplier).
2. **Calendar vs. Actual Weather Disconnect**: In early autumn (September/October), ambient temperatures can still be $\ge 25^\circ\text{C}$ / hot. However, because the calendar said `fall`, summer items like shorts were hit with an off-season penalty (`0.6`), dropping them below long trousers in the pre-ranking list even on very warm days.
3. **Prompt Starvation**: The pre-ranking algorithm slices `TOP_N = 70` candidate items to include in the recommendation prompt. Because of the `all-season` penalty, all sneakers fell below rank 70, leaving only sandals as available footwear in the prompt. The LLM was forced to choose sandals for every outfit.

### Changes
- **`all-season` Compatibility**: Updated `_season_score()` in `backend/app/services/item_scorer.py` to return `1.0` when `"all-season" in seasons`, ensuring all-season pieces match across all seasons.
- **Weather-Aware Season Scoring**: Updated `_season_score()` to evaluate actual weather temperature against `hot_threshold` (default 25°C) and `cold_threshold` (default 10°C):
  - In warm weather ($\ge \text{hot\_threshold}$), `summer` items receive a `1.0` season score.
  - In cold weather ($\le \text{cold\_threshold}$), `winter` items receive a `1.0` season score.
- **Category Diversity Safeguard**: Added `_ensure_role_diversity()` to `score_items()` so that essential outfit roles (like footwear) always retain representation in the top items sent to the AI prompt.
- **Unit Tests**: Added tests in `backend/tests/test_item_scorer.py` for all-season scoring, hot/cool autumn weather, cold spring weather, and role diversity preservation.

### Verification
- All 121 tests pass in `tests/test_item_scorer.py` and `tests/test_recommendation_service.py`.
- Verified live: sneakers score ~0.88 (ranking in top 30–40) alongside sandals (~0.66), and shorts score ~1.08 on warm days, giving the LLM a balanced selection of footwear and bottoms.

## Summary by Sourcery

Improve recommendation ranking so seasonal scoring reflects both item compatibility and current weather while maintaining essential outfit-role diversity.

New Features:
- Preserve footwear and bottom candidates in the recommendation prompt when their scores would otherwise exclude them from the top-ranked set.

Bug Fixes:
- Treat all-season items as compatible year-round and account for actual temperature when scoring summer and winter items against the calendar season.

Enhancements:
- Centralize configurable temperature threshold handling, including user temperature-sensitivity preferences.

Tests:
- Add coverage for all-season scoring, weather-aware seasonal matching, temperature thresholds, and essential-role diversity.