### PR TITLE
feat(suggest): add base item selection and 3-look comparison view

### DIFF
--- a/backend/app/api/outfits.py
+++ b/backend/app/api/outfits.py
@@ -236,10 +236,6 @@ class BulkDeleteOutfitsRequest(BaseModel):
     excluded_ids: list[UUID] | None = None
     filters: BulkOutfitFilters | None = None
 
-    # Cursor into a select_all walk; see BulkSelectionRequest in schemas/item.py
-    # for why a capped select_all is resumed rather than rejected.
-    after_id: UUID | None = None
-
     def model_post_init(self, __context):
         if not self.select_all and not self.outfit_ids:
             raise ValueError("Either outfit_ids or select_all=True must be provided")
@@ -251,8 +247,6 @@ class BulkDeleteOutfitsResponse(BaseModel):
     deleted: int
     failed: int
     errors: list[str] = Field(default_factory=list)
-    next_cursor: UUID | None = None
-    has_more: bool = False
 
 
 class FeedbackRequest(BaseModel):
@@ -504,6 +498,82 @@ async def suggest_outfit(
     return outfit_to_response(outfit, wore_instead_map, is_starter_suggestion=is_starter)
 
 
+@router.post("/suggest-options", response_model=list[OutfitResponse])
+async def suggest_outfit_options(
+    request: SuggestRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> list[OutfitResponse]:
+    await rate_limit_by_user(str(current_user.id), "suggest", max_requests=10, window_seconds=60)
+    weather_override = None
+    if request.weather_override:
+        w = request.weather_override
+        weather_override = WeatherData(
+            temperature=w.temperature,
+            feels_like=w.feels_like or w.temperature,
+            humidity=w.humidity,
+            precipitation_chance=w.precipitation_chance,
+            precipitation_mm=0,
+            wind_speed=0,
+            condition=w.condition,
+            condition_code=0,
+            is_day=True,
+            uv_index=0,
+            timestamp=datetime.utcnow(),
+        )
+
+    service = RecommendationService(db)
+
+    occasion = request.occasion
+    if occasion is None:
+        if current_user.preferences and current_user.preferences.default_occasion:
+            occasion = current_user.preferences.default_occasion
+        else:
+            occasion = "casual"
+
+    try:
+        outfits = await service.generate_recommendations(
+            user=current_user,
+            occasion=occasion,
+            weather_override=weather_override,
+            exclude_items=request.exclude_items,
+            include_items=request.include_items,
+            time_of_day=request.time_of_day,
+            count=3,
+        )
+    except InsufficientWardrobeError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from None
+    except AIDisabledError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Internal AI is disabled; outfit suggestions are deferred to an external agent.",
+        ) from None
+    except AIRecommendationError as e:
+        logger.error(f"AI recommendation error: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(e),
+        ) from None
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from None
+
+    item_service = ItemService(db)
+    total_items = await item_service.get_ready_item_count(current_user.id)
+    is_starter = total_items <= 5
+
+    wore_instead_map = await fetch_wore_instead_items_map(db, outfits, user_id=current_user.id)
+    return [
+        outfit_to_response(outfit, wore_instead_map, is_starter_suggestion=is_starter)
+        for outfit in outfits
+    ]
+
+
 class SuggestionCreateRequest(OutfitAttributeFields):
     model_config = ConfigDict(extra="forbid")
 
@@ -643,9 +713,6 @@ async def bulk_delete_outfits(
     deleted = 0
     failed = 0
     errors: list[str] = []
-    limit = get_settings().max_bulk_action_count
-    next_cursor: UUID | None = None
-    has_more = False
 
     if request.select_all:
         list_filters = OutfitListFilters(
@@ -667,20 +734,10 @@ async def bulk_delete_outfits(
         outfit_ids = await service.get_ids_by_filter(
             list_filters,
             excluded_ids=list(request.excluded_ids) if request.excluded_ids else None,
-            after_id=request.after_id,
-            limit=limit + 1,
         )
-        has_more = len(outfit_ids) > limit
-        outfit_ids = outfit_ids[:limit]
-        next_cursor = outfit_ids[-1] if has_more and outfit_ids else None
-        logger.info(f"Bulk delete select_all: {len(outfit_ids)} outfits, has_more={has_more}")
+        logger.info(f"Bulk delete select_all: {len(outfit_ids)} outfits to delete")
     else:
         outfit_ids = request.outfit_ids or []
-        if len(outfit_ids) > limit:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Maximum {limit} outfits per bulk action",
-            )
 
     for outfit_id in outfit_ids:
         try:
@@ -704,13 +761,7 @@ async def bulk_delete_outfits(
 
     await db.commit()
 
-    return BulkDeleteOutfitsResponse(
-        deleted=deleted,
-        failed=failed,
-        errors=errors,
-        next_cursor=next_cursor,
-        has_more=has_more,
-    )
+    return BulkDeleteOutfitsResponse(deleted=deleted, failed=failed, errors=errors)
 
 
 @router.get("/{outfit_id}", response_model=OutfitResponse)

--- a/backend/app/api/outfits.py
+++ b/backend/app/api/outfits.py
@@ -236,6 +236,10 @@ class BulkDeleteOutfitsRequest(BaseModel):
     excluded_ids: list[UUID] | None = None
     filters: BulkOutfitFilters | None = None
 
+    # Cursor into a select_all walk; see BulkSelectionRequest in schemas/item.py
+    # for why a capped select_all is resumed rather than rejected.
+    after_id: UUID | None = None
+
     def model_post_init(self, __context):
         if not self.select_all and not self.outfit_ids:
             raise ValueError("Either outfit_ids or select_all=True must be provided")
@@ -247,6 +251,8 @@ class BulkDeleteOutfitsResponse(BaseModel):
     deleted: int
     failed: int
     errors: list[str] = Field(default_factory=list)
+    next_cursor: UUID | None = None
+    has_more: bool = False
 
 
 class FeedbackRequest(BaseModel):
@@ -713,6 +719,9 @@ async def bulk_delete_outfits(
     deleted = 0
     failed = 0
     errors: list[str] = []
+    limit = get_settings().max_bulk_action_count
+    next_cursor: UUID | None = None
+    has_more = False
 
     if request.select_all:
         list_filters = OutfitListFilters(
@@ -734,10 +743,20 @@ async def bulk_delete_outfits(
         outfit_ids = await service.get_ids_by_filter(
             list_filters,
             excluded_ids=list(request.excluded_ids) if request.excluded_ids else None,
+            after_id=request.after_id,
+            limit=limit + 1,
         )
-        logger.info(f"Bulk delete select_all: {len(outfit_ids)} outfits to delete")
+        has_more = len(outfit_ids) > limit
+        outfit_ids = outfit_ids[:limit]
+        next_cursor = outfit_ids[-1] if has_more and outfit_ids else None
+        logger.info(f"Bulk delete select_all: {len(outfit_ids)} outfits, has_more={has_more}")
     else:
         outfit_ids = request.outfit_ids or []
+        if len(outfit_ids) > limit:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Maximum {limit} outfits per bulk action",
+            )
 
     for outfit_id in outfit_ids:
         try:
@@ -761,7 +780,13 @@ async def bulk_delete_outfits(
 
     await db.commit()
 
-    return BulkDeleteOutfitsResponse(deleted=deleted, failed=failed, errors=errors)
+    return BulkDeleteOutfitsResponse(
+        deleted=deleted,
+        failed=failed,
+        errors=errors,
+        next_cursor=next_cursor,
+        has_more=has_more,
+    )
 
 
 @router.get("/{outfit_id}", response_model=OutfitResponse)

--- a/backend/app/services/recommendation_service.py
+++ b/backend/app/services/recommendation_service.py
@@ -31,7 +31,7 @@ from app.services.weather_service import (
     WeatherService,
     WeatherServiceError,
 )
-from app.utils.clothing import deduplicate_by_body_slot
+from app.utils.clothing import canonical_item_order, deduplicate_by_body_slot
 from app.utils.prompts import load_prompt
 from app.utils.timezone import get_user_today
 
@@ -188,6 +188,38 @@ class RecommendationService:
         logger.info(f"Found {len(combinations)} worn outfit combinations in last {days} days")
         return combinations
 
+    async def _get_recently_suggested_outfit_combinations(
+        self, user: User, hours: int = 12
+    ) -> set[frozenset[UUID]]:
+        if hours <= 0:
+            return set()
+
+        cutoff_time = datetime.now(UTC) - timedelta(hours=hours)
+
+        query = (
+            select(Outfit)
+            .where(
+                and_(
+                    Outfit.user_id == user.id,
+                    Outfit.created_at >= cutoff_time,
+                )
+            )
+            .order_by(Outfit.created_at.desc())
+            .limit(10)
+            .options(selectinload(Outfit.items))
+        )
+
+        result = await self.db.execute(query)
+        recent_outfits = list(result.scalars().all())
+
+        combinations = set()
+        for outfit in recent_outfits:
+            item_ids = frozenset(outfit_item.item_id for outfit_item in outfit.items)
+            if len(item_ids) >= 2:
+                combinations.add(item_ids)
+
+        return combinations
+
     def _format_items_for_prompt(
         self,
         scored_items: list,
@@ -287,8 +319,9 @@ class RecommendationService:
         mandatory_refs = ", ".join(f"[{n}]" for n in mandatory_numbers_sorted)
         return (
             f"MANDATORY ITEMS (MUST include in every outfit):\n"
-            f"The following items are already selected and MUST appear in all 3 outfit suggestions: {mandatory_refs}\n\n"
-            f"Complete each outfit with complementary pieces from the available items above."
+            f"The following items are already selected and MUST appear in all outfit suggestions: {mandatory_refs}\n\n"
+            f"Complete each outfit with complementary pieces from the available items above. "
+            f"Every generated outfit option MUST include all mandatory items listed above ({mandatory_refs})."
         )
 
     def _format_preferences_for_prompt(
@@ -389,7 +422,7 @@ class RecommendationService:
                     worn_sets.append("[" + ", ".join(map(str, numbers)) + "]")
             if worn_sets:
                 lines.append(
-                    f"- Recently worn outfits (prefer variety, only repeat if necessary): {', '.join(worn_sets)}"
+                    f"- Recently worn or suggested outfits (prefer variety, do not repeat identical combinations): {', '.join(worn_sets)}"
                 )
 
         if lines:
@@ -560,6 +593,7 @@ class RecommendationService:
         source: OutfitSource,
         number_map: dict[int, UUID],
         scheduled_date: date | None = None,
+        mandatory_item_ids: set[UUID] | None = None,
     ) -> Outfit:
         selected_numbers = outfit_data.get("items", [])
         valid_ids = []
@@ -582,6 +616,16 @@ class RecommendationService:
                 unique_ids.append(item_id)
         valid_ids = unique_ids
 
+        # Ensure all mandatory items are included in valid_ids if they were candidates
+        if mandatory_item_ids:
+            mandatory_in_candidates = {
+                item_id for item_id in mandatory_item_ids if item_id in number_map.values()
+            }
+            for mid in mandatory_in_candidates:
+                if mid not in valid_ids:
+                    logger.info(f"Adding missing mandatory item {mid} to outfit")
+                    valid_ids.insert(0, mid)
+
         if not valid_ids:
             raise AIRecommendationError("AI did not select any valid items")
 
@@ -590,7 +634,10 @@ class RecommendationService:
             select(ClothingItem.id, ClothingItem.type).where(ClothingItem.id.in_(valid_ids))
         )
         item_type_map = {row.id: (row.type or "").lower() for row in items_result}
-        valid_ids = deduplicate_by_body_slot(valid_ids, item_type_map)
+        valid_ids = deduplicate_by_body_slot(
+            valid_ids, item_type_map, mandatory_item_ids=mandatory_item_ids
+        )
+        valid_ids = canonical_item_order(valid_ids, item_type_map)
 
         reasoning = outfit_data.get("headline") or outfit_data.get("reasoning")
         style_notes = outfit_data.get("styling_tip") or outfit_data.get("style_notes")
@@ -643,7 +690,7 @@ class RecommendationService:
         logger.info(f"Created outfit {outfit.id} with {len(valid_ids)} items")
         return outfit
 
-    async def generate_recommendation(
+    async def generate_recommendations(
         self,
         user: User,
         occasion: str,
@@ -652,9 +699,10 @@ class RecommendationService:
         include_items: list[UUID] | None = None,
         source: OutfitSource = OutfitSource.on_demand,
         time_of_day: str | None = None,
+        count: int = 1,
         single_outfit: bool = False,
         scheduled_date: date | None = None,
-    ) -> Outfit:
+    ) -> list[Outfit]:
         # Guard first so deferral is unconditional, before any location/weather work.
         require_internal_ai("text")
 
@@ -665,7 +713,7 @@ class RecommendationService:
             time_of_day = get_time_of_day(user)
 
         # Determine cache eligibility before auto-merge
-        use_cache = not exclude_items and not include_items and not single_outfit
+        use_cache = not exclude_items and not single_outfit
 
         # Auto-exclude today's rejected items for this occasion
         rejected_ids = await self._get_today_rejected_item_ids(user, occasion)
@@ -737,38 +785,50 @@ class RecommendationService:
                 candidates.extend(forced_items)
                 logger.info(f"Force-included {len(forced_items)} items in recommendation")
 
+            unresolved = include_set - {item.id for item in candidates}
+            if unresolved:
+                raise ValueError("One or more selected items could not be found or are not ready.")
+
         if len(candidates) < 2:
             raise InsufficientWardrobeError(
                 "Not enough items in wardrobe for recommendation. "
                 "Please add more items or adjust filters."
             )
 
-        # Check cache for pre-generated suggestions
-        if use_cache:
-            cached = await pop_suggestion(user.id, occasion)
-            if cached:
+        # Check cache for pre-generated suggestions (used when count is 1)
+        if use_cache and count == 1:
+            while True:
+                cached = await pop_suggestion(user.id, occasion, include_items=include_items)
+                if not cached:
+                    break
                 cached_number_map = cached.get("_number_map", {})
                 number_map = {int(k): UUID(v) for k, v in cached_number_map.items()}
 
                 cached_item_ids = set()
                 for num in cached.get("items", []):
-                    str_num = str(int(num))
-                    if str_num in cached_number_map:
-                        cached_item_ids.add(UUID(cached_number_map[str_num]))
+                    try:
+                        str_num = str(int(num))
+                        if str_num in cached_number_map:
+                            cached_item_ids.add(UUID(cached_number_map[str_num]))
+                    except (ValueError, TypeError):
+                        pass
 
                 if cached_item_ids & rejected_ids:
                     logger.info("Cached suggestion contains rejected items, skipping")
-                else:
-                    logger.info(f"Using cached suggestion for user {user.id}, occasion: {occasion}")
-                    return await self._materialize_outfit(
-                        cached,
-                        user,
-                        weather,
-                        occasion,
-                        source,
-                        number_map,
-                        scheduled_date=scheduled_date,
-                    )
+                    continue
+
+                logger.info(f"Using cached suggestion for user {user.id}, occasion: {occasion}")
+                outfit = await self._materialize_outfit(
+                    cached,
+                    user,
+                    weather,
+                    occasion,
+                    source,
+                    number_map,
+                    scheduled_date=scheduled_date,
+                    mandatory_item_ids=set(include_items) if include_items else None,
+                )
+                return [outfit]
 
         # Fetch scoring context
         recently_worn_dates = await self._get_recently_worn_dates(user)
@@ -801,11 +861,13 @@ class RecommendationService:
         mandatory_items_section = self._format_mandatory_items_section(include_items, number_map)
 
         worn_combinations = await self._get_recently_worn_outfit_combinations(user, days=7)
+        suggested_combinations = await self._get_recently_suggested_outfit_combinations(user, hours=12)
+        avoid_combinations = worn_combinations | suggested_combinations
 
         preferences_text = self._format_preferences_for_prompt(
             preferences,
             learned_prefs,
-            worn_combinations,
+            avoid_combinations,
             number_map,
             occasion=occasion,
             body_measurements=getattr(user, "body_measurements", None),
@@ -853,7 +915,7 @@ class RecommendationService:
                     raise ValueError(f"Expected dict, got {type(outfit_data)}")
                 outfit_data["_ai_model"] = result.model
                 outfit_data["_ai_endpoint"] = result.endpoint
-                return await self._materialize_outfit(
+                outfit = await self._materialize_outfit(
                     outfit_data,
                     user,
                     weather,
@@ -861,38 +923,42 @@ class RecommendationService:
                     source,
                     number_map,
                     scheduled_date=scheduled_date,
+                    mandatory_item_ids=set(include_items) if include_items else None,
                 )
+                return [outfit]
 
             # Multi-outfit parse
             outfit_list = self._parse_multi_outfit_response(result.content)
 
-            first = outfit_list[0]
-            first["_ai_model"] = result.model
-            first["_ai_endpoint"] = result.endpoint
-
-            outfit = await self._materialize_outfit(
-                first,
-                user,
-                weather,
-                occasion,
-                source,
-                number_map,
-                scheduled_date=scheduled_date,
-            )
+            outfits = []
+            for od in outfit_list[:count]:
+                od["_ai_model"] = result.model
+                od["_ai_endpoint"] = result.endpoint
+                outfit = await self._materialize_outfit(
+                    od,
+                    user,
+                    weather,
+                    occasion,
+                    source,
+                    number_map,
+                    scheduled_date=scheduled_date,
+                    mandatory_item_ids=set(include_items) if include_items else None,
+                )
+                outfits.append(outfit)
 
             # Cache remaining outfits for "Try Another"
-            if len(outfit_list) > 1:
+            if use_cache and len(outfit_list) > count:
                 serializable_map = {str(k): str(v) for k, v in number_map.items()}
                 to_cache = []
-                for od in outfit_list[1:]:
+                for od in outfit_list[count:]:
                     od["_number_map"] = serializable_map
                     od["_ai_model"] = result.model
                     od["_ai_endpoint"] = result.endpoint
                     to_cache.append(od)
-                await push_suggestions(user.id, occasion, to_cache)
+                await push_suggestions(user.id, occasion, to_cache, include_items=include_items)
                 logger.info(f"Cached {len(to_cache)} additional suggestions for user {user.id}")
 
-            return outfit
+            return outfits
 
         except AIRecommendationError:
             raise
@@ -907,6 +973,32 @@ class RecommendationService:
             raise AIRecommendationError(
                 "AI service is not available. Please check your AI endpoint configuration in Settings."
             ) from e
+
+    async def generate_recommendation(
+        self,
+        user: User,
+        occasion: str,
+        weather_override: WeatherData | None = None,
+        exclude_items: list[UUID] | None = None,
+        include_items: list[UUID] | None = None,
+        source: OutfitSource = OutfitSource.on_demand,
+        time_of_day: str | None = None,
+        single_outfit: bool = False,
+        scheduled_date: date | None = None,
+    ) -> Outfit:
+        outfits = await self.generate_recommendations(
+            user=user,
+            occasion=occasion,
+            weather_override=weather_override,
+            exclude_items=exclude_items,
+            include_items=include_items,
+            source=source,
+            time_of_day=time_of_day,
+            count=1,
+            single_outfit=single_outfit,
+            scheduled_date=scheduled_date,
+        )
+        return outfits[0]
 
 
 class InsufficientWardrobeError(Exception):

--- a/backend/app/services/recommendation_service.py
+++ b/backend/app/services/recommendation_service.py
@@ -861,7 +861,9 @@ class RecommendationService:
         mandatory_items_section = self._format_mandatory_items_section(include_items, number_map)
 
         worn_combinations = await self._get_recently_worn_outfit_combinations(user, days=7)
-        suggested_combinations = await self._get_recently_suggested_outfit_combinations(user, hours=12)
+        suggested_combinations = await self._get_recently_suggested_outfit_combinations(
+            user, hours=12
+        )
         avoid_combinations = worn_combinations | suggested_combinations
 
         preferences_text = self._format_preferences_for_prompt(

--- a/backend/app/services/suggestion_cache.py
+++ b/backend/app/services/suggestion_cache.py
@@ -9,14 +9,19 @@ CACHE_TTL = 3600
 KEY_PREFIX = "suggest"
 
 
-def _cache_key(user_id, occasion) -> str:
+def _cache_key(user_id, occasion, include_items: list | None = None) -> str:
+    if include_items:
+        items_part = ":".join(sorted(str(i) for i in include_items))
+        return f"{KEY_PREFIX}:{user_id}:{occasion}:{items_part}"
     return f"{KEY_PREFIX}:{user_id}:{occasion}"
 
 
-async def push_suggestions(user_id, occasion, suggestions: list[dict]) -> None:
+async def push_suggestions(
+    user_id, occasion, suggestions: list[dict], include_items: list | None = None
+) -> None:
     try:
         redis = await get_redis()
-        key = _cache_key(user_id, occasion)
+        key = _cache_key(user_id, occasion, include_items=include_items)
         pipe = redis.pipeline()
         for s in suggestions:
             pipe.rpush(key, json.dumps(s))
@@ -26,10 +31,12 @@ async def push_suggestions(user_id, occasion, suggestions: list[dict]) -> None:
         logger.warning("Failed to push suggestions to cache", exc_info=True)
 
 
-async def pop_suggestion(user_id, occasion) -> dict | None:
+async def pop_suggestion(
+    user_id, occasion, include_items: list | None = None
+) -> dict | None:
     try:
         redis = await get_redis()
-        key = _cache_key(user_id, occasion)
+        key = _cache_key(user_id, occasion, include_items=include_items)
         raw = await redis.lpop(key)
         if raw is None:
             return None
@@ -39,19 +46,28 @@ async def pop_suggestion(user_id, occasion) -> dict | None:
         return None
 
 
-async def clear_suggestions(user_id, occasion) -> None:
+async def clear_suggestions(
+    user_id, occasion, include_items: list | None = None
+) -> None:
     try:
         redis = await get_redis()
-        key = _cache_key(user_id, occasion)
-        await redis.delete(key)
+        base_key = _cache_key(user_id, occasion, include_items=include_items)
+        await redis.delete(base_key)
+        if include_items is None:
+            scan_iter = getattr(redis, "scan_iter", None)
+            if callable(scan_iter):
+                async for key in scan_iter(f"{base_key}:*"):
+                    await redis.delete(key)
     except Exception:
         logger.warning("Failed to clear suggestion cache", exc_info=True)
 
 
-async def has_cached(user_id, occasion) -> bool:
+async def has_cached(
+    user_id, occasion, include_items: list | None = None
+) -> bool:
     try:
         redis = await get_redis()
-        key = _cache_key(user_id, occasion)
+        key = _cache_key(user_id, occasion, include_items=include_items)
         length = await redis.llen(key)
         return length > 0
     except Exception:

--- a/backend/app/services/suggestion_cache.py
+++ b/backend/app/services/suggestion_cache.py
@@ -7,6 +7,7 @@ logger = logging.getLogger(__name__)
 
 CACHE_TTL = 3600
 KEY_PREFIX = "suggest"
+INDEX_PREFIX = "suggest:idx"
 
 
 def _cache_key(user_id, occasion, include_items: list | None = None) -> str:
@@ -14,6 +15,10 @@ def _cache_key(user_id, occasion, include_items: list | None = None) -> str:
         items_part = ":".join(sorted(str(i) for i in include_items))
         return f"{KEY_PREFIX}:{user_id}:{occasion}:{items_part}"
     return f"{KEY_PREFIX}:{user_id}:{occasion}"
+
+
+def _index_key(user_id, occasion) -> str:
+    return f"{INDEX_PREFIX}:{user_id}:{occasion}"
 
 
 async def push_suggestions(
@@ -26,14 +31,17 @@ async def push_suggestions(
         for s in suggestions:
             pipe.rpush(key, json.dumps(s))
         pipe.expire(key, CACHE_TTL)
+        # Every base-item variant gets its own list key, so the set records which ones
+        # exist. Clearing by SCAN instead would walk the whole keyspace, and this Redis
+        # db also carries the arq tagging queues.
+        pipe.sadd(_index_key(user_id, occasion), key)
+        pipe.expire(_index_key(user_id, occasion), CACHE_TTL)
         await pipe.execute()
     except Exception:
         logger.warning("Failed to push suggestions to cache", exc_info=True)
 
 
-async def pop_suggestion(
-    user_id, occasion, include_items: list | None = None
-) -> dict | None:
+async def pop_suggestion(user_id, occasion, include_items: list | None = None) -> dict | None:
     try:
         redis = await get_redis()
         key = _cache_key(user_id, occasion, include_items=include_items)
@@ -46,25 +54,25 @@ async def pop_suggestion(
         return None
 
 
-async def clear_suggestions(
-    user_id, occasion, include_items: list | None = None
-) -> None:
+async def clear_suggestions(user_id, occasion, include_items: list | None = None) -> None:
     try:
         redis = await get_redis()
-        base_key = _cache_key(user_id, occasion, include_items=include_items)
-        await redis.delete(base_key)
-        if include_items is None:
-            scan_iter = getattr(redis, "scan_iter", None)
-            if callable(scan_iter):
-                async for key in scan_iter(f"{base_key}:*"):
-                    await redis.delete(key)
+        index_key = _index_key(user_id, occasion)
+        if include_items:
+            key = _cache_key(user_id, occasion, include_items=include_items)
+            await redis.delete(key)
+            await redis.srem(index_key, key)
+            return
+
+        # Wardrobe-wide invalidation: every base-item variant is stale too, because the
+        # item the caller just changed can appear in any of them.
+        keys = await redis.smembers(index_key) or set()
+        await redis.delete(_cache_key(user_id, occasion), index_key, *keys)
     except Exception:
         logger.warning("Failed to clear suggestion cache", exc_info=True)
 
 
-async def has_cached(
-    user_id, occasion, include_items: list | None = None
-) -> bool:
+async def has_cached(user_id, occasion, include_items: list | None = None) -> bool:
     try:
         redis = await get_redis()
         key = _cache_key(user_id, occasion, include_items=include_items)

--- a/backend/app/utils/clothing.py
+++ b/backend/app/utils/clothing.py
@@ -37,13 +37,35 @@ ITEM_ROLE: dict[str, str] = {
 }
 
 
-def deduplicate_by_body_slot(item_ids: list[UUID], item_type_map: dict[UUID, str]) -> list[UUID]:
+def deduplicate_by_body_slot(
+    item_ids: list[UUID],
+    item_type_map: dict[UUID, str],
+    mandatory_item_ids: set[UUID] | None = None,
+) -> list[UUID]:
+    mandatory = mandatory_item_ids or set()
     seen_roles: dict[str, UUID] = {}
     result: list[UUID] = []
-    has_full_body = any(
-        ITEM_ROLE.get(item_type_map.get(iid, "")) == "full_body" for iid in item_ids
+
+    mandatory_has_full_body = any(
+        ITEM_ROLE.get(item_type_map.get(iid, "")) == "full_body" for iid in mandatory
     )
+    mandatory_has_separates = any(
+        ITEM_ROLE.get(item_type_map.get(iid, "")) in ("base_top", "bottom") for iid in mandatory
+    )
+
+    has_full_body = (
+        any(ITEM_ROLE.get(item_type_map.get(iid, "")) == "full_body" for iid in item_ids)
+        and not mandatory_has_separates
+    )
+
     for iid in item_ids:
+        if iid in mandatory:
+            role = ITEM_ROLE.get(item_type_map.get(iid, ""))
+            if role and role != "accessory":
+                seen_roles[role] = iid
+
+    for iid in item_ids:
+        is_mand = iid in mandatory
         item_type = item_type_map.get(iid, "")
         role = ITEM_ROLE.get(item_type)
         if not role:
@@ -52,17 +74,24 @@ def deduplicate_by_body_slot(item_ids: list[UUID], item_type_map: dict[UUID, str
         if role == "accessory":
             result.append(iid)
             continue
-        if has_full_body and role in ("base_top", "bottom"):
-            logger.warning(f"Removing {item_type} item {iid}: full_body item present")
-            continue
-        if role in seen_roles:
-            logger.warning(
-                f"Removing duplicate {role} item {iid} ({item_type}): "
-                f"role already filled by {seen_roles[role]}"
-            )
-            continue
+
+        if not is_mand:
+            if role == "full_body" and mandatory_has_separates:
+                logger.warning(f"Removing {item_type} item {iid}: mandatory separates present")
+                continue
+            if (has_full_body or mandatory_has_full_body) and role in ("base_top", "bottom"):
+                logger.warning(f"Removing {item_type} item {iid}: full_body item present")
+                continue
+            if role in seen_roles and seen_roles[role] != iid:
+                logger.warning(
+                    f"Removing duplicate {role} item {iid} ({item_type}): "
+                    f"role already filled by {seen_roles[role]}"
+                )
+                continue
+
         seen_roles[role] = iid
-        result.append(iid)
+        if iid not in result:
+            result.append(iid)
     return result
 
 

--- a/backend/app/utils/clothing.py
+++ b/backend/app/utils/clothing.py
@@ -42,56 +42,61 @@ def deduplicate_by_body_slot(
     item_type_map: dict[UUID, str],
     mandatory_item_ids: set[UUID] | None = None,
 ) -> list[UUID]:
-    mandatory = mandatory_item_ids or set()
-    seen_roles: dict[str, UUID] = {}
+    requested = mandatory_item_ids or set()
     result: list[UUID] = []
 
-    mandatory_has_full_body = any(
-        ITEM_ROLE.get(item_type_map.get(iid, "")) == "full_body" for iid in mandatory
-    )
-    mandatory_has_separates = any(
-        ITEM_ROLE.get(item_type_map.get(iid, "")) in ("base_top", "bottom") for iid in mandatory
-    )
-
-    has_full_body = (
-        any(ITEM_ROLE.get(item_type_map.get(iid, "")) == "full_body" for iid in item_ids)
-        and not mandatory_has_separates
-    )
-
+    # A mandatory item only claims a slot if the caller actually passed it in item_ids;
+    # one that never made the candidate list must not block the items that did.
+    # Mandatory items compete with each other too, first in list order wins, because two
+    # shirts or a dress plus trousers is an unwearable outfit however it was requested.
+    mandatory_roles: dict[str, UUID] = {}
+    body_claim: str | None = None
     for iid in item_ids:
-        if iid in mandatory:
-            role = ITEM_ROLE.get(item_type_map.get(iid, ""))
-            if role and role != "accessory":
-                seen_roles[role] = iid
+        if iid not in requested:
+            continue
+        role = ITEM_ROLE.get(item_type_map.get(iid, ""))
+        if not role or role == "accessory" or role in mandatory_roles:
+            continue
+        if role == "full_body":
+            if body_claim == "separates":
+                continue
+            body_claim = "full_body"
+        elif role in ("base_top", "bottom"):
+            if body_claim == "full_body":
+                continue
+            body_claim = "separates"
+        mandatory_roles[role] = iid
 
+    mandatory_has_separates = body_claim == "separates"
+    has_full_body = body_claim == "full_body" or (
+        not mandatory_has_separates
+        and any(ITEM_ROLE.get(item_type_map.get(iid, "")) == "full_body" for iid in item_ids)
+    )
+
+    seen_roles: dict[str, UUID] = dict(mandatory_roles)
     for iid in item_ids:
-        is_mand = iid in mandatory
         item_type = item_type_map.get(iid, "")
         role = ITEM_ROLE.get(item_type)
-        if not role:
+        if not role or role == "accessory":
             result.append(iid)
             continue
-        if role == "accessory":
+        if mandatory_roles.get(role) == iid:
             result.append(iid)
             continue
-
-        if not is_mand:
-            if role == "full_body" and mandatory_has_separates:
-                logger.warning(f"Removing {item_type} item {iid}: mandatory separates present")
-                continue
-            if (has_full_body or mandatory_has_full_body) and role in ("base_top", "bottom"):
-                logger.warning(f"Removing {item_type} item {iid}: full_body item present")
-                continue
-            if role in seen_roles and seen_roles[role] != iid:
-                logger.warning(
-                    f"Removing duplicate {role} item {iid} ({item_type}): "
-                    f"role already filled by {seen_roles[role]}"
-                )
-                continue
-
+        if role == "full_body" and mandatory_has_separates:
+            logger.warning(f"Removing {item_type} item {iid}: mandatory separates present")
+            continue
+        if has_full_body and role in ("base_top", "bottom"):
+            logger.warning(f"Removing {item_type} item {iid}: full_body item present")
+            continue
+        if role in seen_roles:
+            logger.warning(
+                f"Removing duplicate {role} item {iid} ({item_type}): "
+                f"role already filled by {seen_roles[role]}"
+            )
+            continue
         seen_roles[role] = iid
-        if iid not in result:
-            result.append(iid)
+        result.append(iid)
     return result
 
 

--- a/backend/tests/test_clothing_utils.py
+++ b/backend/tests/test_clothing_utils.py
@@ -202,3 +202,57 @@ def test_canonical_order_full_outfit():
 def test_canonical_order_empty_list():
     result = canonical_item_order([], {})
     assert result == []
+
+
+def test_mandatory_item_overrides_earlier_duplicate():
+    ai_shirt_id, mandatory_shirt_id, pants_id = _ids(3)
+    item_type_map = {
+        ai_shirt_id: "t-shirt",
+        mandatory_shirt_id: "polo",
+        pants_id: "jeans",
+    }
+    result = deduplicate_by_body_slot(
+        [ai_shirt_id, mandatory_shirt_id, pants_id],
+        item_type_map,
+        mandatory_item_ids={mandatory_shirt_id},
+    )
+    assert mandatory_shirt_id in result
+    assert ai_shirt_id not in result
+    assert pants_id in result
+
+
+def test_mandatory_separate_drops_non_mandatory_full_body():
+    dress_id, mandatory_pants_id, shoes_id = _ids(3)
+    item_type_map = {
+        dress_id: "dress",
+        mandatory_pants_id: "pants",
+        shoes_id: "sneakers",
+    }
+    result = deduplicate_by_body_slot(
+        [dress_id, mandatory_pants_id, shoes_id],
+        item_type_map,
+        mandatory_item_ids={mandatory_pants_id},
+    )
+    assert mandatory_pants_id in result
+    assert dress_id not in result
+    assert shoes_id in result
+
+
+def test_mandatory_full_body_drops_non_mandatory_separates():
+    mandatory_dress_id, shirt_id, pants_id, shoes_id = _ids(4)
+    item_type_map = {
+        mandatory_dress_id: "dress",
+        shirt_id: "shirt",
+        pants_id: "jeans",
+        shoes_id: "boots",
+    }
+    result = deduplicate_by_body_slot(
+        [shirt_id, mandatory_dress_id, pants_id, shoes_id],
+        item_type_map,
+        mandatory_item_ids={mandatory_dress_id},
+    )
+    assert mandatory_dress_id in result
+    assert shirt_id not in result
+    assert pants_id not in result
+    assert shoes_id in result
+

--- a/backend/tests/test_clothing_utils.py
+++ b/backend/tests/test_clothing_utils.py
@@ -256,3 +256,35 @@ def test_mandatory_full_body_drops_non_mandatory_separates():
     assert pants_id not in result
     assert shoes_id in result
 
+
+def test_two_mandatory_items_in_one_role_do_not_both_survive():
+    shirt_a, shirt_b, pants_id = _ids(3)
+    item_type_map = {shirt_a: "shirt", shirt_b: "polo", pants_id: "jeans"}
+    result = deduplicate_by_body_slot(
+        [shirt_a, shirt_b, pants_id],
+        item_type_map,
+        mandatory_item_ids={shirt_a, shirt_b},
+    )
+    assert result == [shirt_a, pants_id]
+
+
+def test_mandatory_full_body_and_mandatory_separates_do_not_coexist():
+    dress_id, pants_id, shoes_id = _ids(3)
+    item_type_map = {dress_id: "dress", pants_id: "jeans", shoes_id: "boots"}
+    result = deduplicate_by_body_slot(
+        [dress_id, pants_id, shoes_id],
+        item_type_map,
+        mandatory_item_ids={dress_id, pants_id},
+    )
+    assert result == [dress_id, shoes_id]
+
+
+def test_mandatory_item_absent_from_candidates_does_not_empty_its_role():
+    absent_shirt, shirt_id, pants_id = _ids(3)
+    item_type_map = {shirt_id: "shirt", pants_id: "jeans"}
+    result = deduplicate_by_body_slot(
+        [shirt_id, pants_id],
+        item_type_map,
+        mandatory_item_ids={absent_shirt},
+    )
+    assert result == [shirt_id, pants_id]

--- a/backend/tests/test_outfits_bulk_delete.py
+++ b/backend/tests/test_outfits_bulk_delete.py
@@ -6,6 +6,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import get_settings
 from app.models.item import ClothingItem, ItemStatus
 from app.models.outfit import Outfit, OutfitItem, OutfitSource, OutfitStatus
 from app.models.user import User
@@ -249,3 +250,60 @@ class TestBulkDeleteRequestValidation:
             headers=auth_headers,
         )
         assert response.status_code == 422
+
+
+class TestBulkDeleteResourceLimits:
+    """A select_all walk must stay capped and resumable.
+
+    Nothing else in the suite exercises the cap, which is how a revert of it once slipped
+    through green.
+    """
+
+    @pytest.mark.asyncio
+    async def test_explicit_ids_over_the_cap_are_rejected(
+        self, client: AsyncClient, test_user, auth_headers
+    ):
+        limit = get_settings().max_bulk_action_count
+        response = await client.post(
+            "/api/v1/outfits/bulk/delete",
+            json={"outfit_ids": [str(uuid4()) for _ in range(limit + 1)]},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 400
+        assert str(limit) in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_select_all_caps_each_batch_and_returns_a_cursor(
+        self, client: AsyncClient, test_user, auth_headers, db_session: AsyncSession, monkeypatch
+    ):
+        monkeypatch.setattr(get_settings(), "max_bulk_action_count", 3, raising=False)
+
+        item = _make_item(test_user.id)
+        db_session.add(item)
+        await db_session.flush()
+        db_session.add_all([_make_outfit(test_user.id, [item]) for _ in range(5)])
+        await db_session.commit()
+
+        first = await client.post(
+            "/api/v1/outfits/bulk/delete",
+            json={"select_all": True},
+            headers=auth_headers,
+        )
+        assert first.status_code == 200
+        body = first.json()
+        assert body["deleted"] == 3
+        assert body["has_more"] is True
+        assert body["next_cursor"] is not None
+
+        second = await client.post(
+            "/api/v1/outfits/bulk/delete",
+            json={"select_all": True, "after_id": body["next_cursor"]},
+            headers=auth_headers,
+        )
+        assert second.status_code == 200
+        assert second.json()["deleted"] == 2
+        assert second.json()["has_more"] is False
+
+        remaining = await db_session.execute(select(Outfit).where(Outfit.user_id == test_user.id))
+        assert remaining.scalars().all() == []

--- a/backend/tests/test_recommendation_service.py
+++ b/backend/tests/test_recommendation_service.py
@@ -1,5 +1,5 @@
 from datetime import UTC, date, datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -433,3 +433,183 @@ class TestPromptPreRanking:
         from app.services.recommendation_service import RECOMMENDATION_PROMPT
 
         assert "pre-ranked" in RECOMMENDATION_PROMPT
+
+
+class TestIncludeItems:
+    def test_format_mandatory_items_section(self):
+        service = RecommendationService.__new__(RecommendationService)
+        id1, id2, id3 = uuid4(), uuid4(), uuid4()
+        id_to_number = {1: id1, 2: id2, 3: id3}
+
+        section = service._format_mandatory_items_section([id2], id_to_number)
+        assert "[2]" in section
+        assert "MANDATORY ITEMS" in section
+        assert "MUST appear in all outfit suggestions" in section
+
+    @pytest.mark.asyncio
+    async def test_materialize_outfit_enforces_mandatory_item_even_if_omitted_by_ai(
+        self, db_session, test_user
+    ):
+        mand_item = ClothingItem(
+            user_id=test_user.id,
+            type="shirt",
+            image_path=f"test/{uuid4()}.jpg",
+            status=ItemStatus.ready,
+            primary_color="blue",
+        )
+        ai_item = ClothingItem(
+            user_id=test_user.id,
+            type="pants",
+            image_path=f"test/{uuid4()}.jpg",
+            status=ItemStatus.ready,
+            primary_color="black",
+        )
+        db_session.add_all([mand_item, ai_item])
+        await db_session.commit()
+
+        service = RecommendationService(db_session)
+        weather = WeatherData(
+            temperature=20,
+            feels_like=20,
+            humidity=50,
+            precipitation_chance=0,
+            precipitation_mm=0,
+            wind_speed=0,
+            condition="clear",
+            condition_code=0,
+            is_day=True,
+            uv_index=0,
+            timestamp=datetime.utcnow(),
+        )
+        number_map = {1: mand_item.id, 2: ai_item.id}
+        # AI returned only item 2, omitting item 1
+        outfit_data = {"items": [2], "headline": "Casual day"}
+
+        outfit = await service._materialize_outfit(
+            outfit_data,
+            test_user,
+            weather,
+            occasion="casual",
+            source=OutfitSource.on_demand,
+            number_map=number_map,
+            mandatory_item_ids={mand_item.id},
+        )
+
+        outfit_item_ids = {oi.item_id for oi in outfit.items}
+        assert mand_item.id in outfit_item_ids
+        assert ai_item.id in outfit_item_ids
+
+    @pytest.mark.asyncio
+    async def test_suggest_accepts_include_items(
+        self, client, test_user, auth_headers, db_session
+    ):
+        item = ClothingItem(
+            user_id=test_user.id,
+            type="shirt",
+            image_path=f"test/{uuid4()}.jpg",
+            status=ItemStatus.ready,
+            primary_color="blue",
+        )
+        outfit = Outfit(
+            user_id=test_user.id,
+            occasion="casual",
+            status=OutfitStatus.pending,
+            source=OutfitSource.on_demand,
+        )
+        outfit.feedback = None
+        outfit.family_ratings = []
+        outfit.items = [OutfitItem(item=item, position=0, layer_type=None)]
+
+        db_session.add_all([item, outfit])
+        await db_session.commit()
+
+        with patch(
+            "app.api.outfits.RecommendationService.generate_recommendation",
+            new_callable=AsyncMock,
+            return_value=outfit,
+        ) as mock_generate:
+            mand_id = uuid4()
+            response = await client.post(
+                "/api/v1/outfits/suggest",
+                json={
+                    "occasion": "casual",
+                    "include_items": [str(mand_id)],
+                    "weather_override": {
+                        "temperature": 20,
+                        "condition": "clear",
+                    },
+                },
+                headers=auth_headers,
+            )
+            assert response.status_code == 200
+            assert mock_generate.call_args.kwargs["include_items"] == [mand_id]
+
+    @pytest.mark.asyncio
+    async def test_unresolved_include_item_raises_value_error(self, db_session, test_user):
+        service = RecommendationService(db_session)
+        weather_override = WeatherData(
+            temperature=20,
+            feels_like=20,
+            humidity=50,
+            precipitation_chance=0,
+            precipitation_mm=0,
+            wind_speed=0,
+            condition="clear",
+            condition_code=0,
+            is_day=True,
+            uv_index=0,
+            timestamp=datetime.utcnow(),
+        )
+        fake_id = uuid4()
+        test_user.preferences = None
+        with pytest.raises(ValueError, match="could not be found"):
+            await service.generate_recommendation(
+                user=test_user,
+                occasion="casual",
+                weather_override=weather_override,
+                include_items=[fake_id],
+            )
+
+    @pytest.mark.asyncio
+    async def test_suggest_options_endpoint_returns_multiple(self, client, auth_headers):
+        with patch.object(
+            RecommendationService,
+            "generate_recommendations",
+            AsyncMock(),
+        ) as mock_generate:
+            fake_outfits = []
+            for _ in range(3):
+                o = MagicMock()
+                o.id = uuid4()
+                o.occasion = "casual"
+                o.scheduled_for = None
+                o.status = MagicMock(value="pending")
+                o.name = None
+                o.replaces_outfit_id = None
+                o.cloned_from_outfit_id = None
+                o.source = MagicMock(value="on_demand")
+                o.reasoning = "Test"
+                o.style_notes = "Test"
+                o.season = None
+                o.formality = None
+                o.palette = None
+                o.notes = None
+                o.weather_data = None
+                o.items = []
+                o.feedback = []
+                o.family_ratings = []
+                o.created_at = datetime.utcnow()
+                fake_outfits.append(o)
+            mock_generate.return_value = fake_outfits
+
+            response = await client.post(
+                "/api/v1/outfits/suggest-options",
+                json={"occasion": "casual"},
+                headers=auth_headers,
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert isinstance(data, list)
+            assert len(data) == 3
+            assert mock_generate.call_args.kwargs["count"] == 3
+

--- a/backend/tests/test_recommendation_service.py
+++ b/backend/tests/test_recommendation_service.py
@@ -500,9 +500,7 @@ class TestIncludeItems:
         assert ai_item.id in outfit_item_ids
 
     @pytest.mark.asyncio
-    async def test_suggest_accepts_include_items(
-        self, client, test_user, auth_headers, db_session
-    ):
+    async def test_suggest_accepts_include_items(self, client, test_user, auth_headers, db_session):
         item = ClothingItem(
             user_id=test_user.id,
             type="shirt",
@@ -612,4 +610,3 @@ class TestIncludeItems:
             assert isinstance(data, list)
             assert len(data) == 3
             assert mock_generate.call_args.kwargs["count"] == 3
-

--- a/backend/tests/test_suggestion_cache.py
+++ b/backend/tests/test_suggestion_cache.py
@@ -96,3 +96,34 @@ class TestSuggestionCache:
 
             await push_suggestions(user_id, "casual", [{"items": [1]}])
             await clear_suggestions(user_id, "casual")
+
+    @pytest.mark.asyncio
+    async def test_push_and_pop_with_include_items(self, user_id, mock_redis):
+        redis, pipe = mock_redis
+        item1 = uuid4()
+        item2 = uuid4()
+
+        with patch("app.services.suggestion_cache.get_redis", AsyncMock(return_value=redis)):
+            suggestions = [
+                {"items": [1, 2], "headline": "Alt 1"},
+                {"items": [1, 3], "headline": "Alt 2"},
+            ]
+            await push_suggestions(user_id, "casual", suggestions, include_items=[item2, item1])
+
+            key = _cache_key(user_id, "casual", include_items=[item1, item2])
+            assert pipe.rpush.call_count == 2
+            assert pipe.rpush.call_args_list[0][0][0] == key
+
+            redis.lpop.return_value = json.dumps({"items": [1, 2], "headline": "Alt 1"})
+            popped = await pop_suggestion(user_id, "casual", include_items=[item1, item2])
+            assert popped == {"items": [1, 2], "headline": "Alt 1"}
+            redis.lpop.assert_called_with(key)
+
+    def test_cache_key_deterministic_sorting(self, user_id):
+        id_a = uuid4()
+        id_b = uuid4()
+        key1 = _cache_key(user_id, "casual", include_items=[id_a, id_b])
+        key2 = _cache_key(user_id, "casual", include_items=[id_b, id_a])
+        assert key1 == key2
+        assert str(id_a) in key1
+        assert str(id_b) in key1

--- a/backend/tests/test_suggestion_cache.py
+++ b/backend/tests/test_suggestion_cache.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.services.suggestion_cache import (
     _cache_key,
+    _index_key,
     clear_suggestions,
     has_cached,
     pop_suggestion,
@@ -24,6 +25,8 @@ def mock_redis():
     redis.lpop = AsyncMock(return_value=None)
     redis.llen = AsyncMock(return_value=0)
     redis.delete = AsyncMock()
+    redis.srem = AsyncMock()
+    redis.smembers = AsyncMock(return_value=set())
 
     pipe = MagicMock()
     pipe.execute = AsyncMock()
@@ -44,7 +47,10 @@ class TestSuggestionCache:
             await push_suggestions(user_id, "casual", suggestions)
 
             assert pipe.rpush.call_count == 2
-            pipe.expire.assert_called_once()
+            pipe.expire.assert_any_call(_cache_key(user_id, "casual"), 3600)
+            pipe.sadd.assert_called_once_with(
+                _index_key(user_id, "casual"), _cache_key(user_id, "casual")
+            )
             pipe.execute.assert_called_once()
 
     @pytest.mark.asyncio
@@ -66,13 +72,36 @@ class TestSuggestionCache:
             assert result == {"items": [1, 2], "headline": "Test"}
 
     @pytest.mark.asyncio
-    async def test_clear_removes_all(self, user_id, mock_redis):
+    async def test_clear_removes_base_item_variants_without_scanning(self, user_id, mock_redis):
         redis, _ = mock_redis
+        item_id = uuid4()
+        variant_key = _cache_key(user_id, "casual", include_items=[item_id])
+        redis.smembers.return_value = {variant_key}
 
         with patch("app.services.suggestion_cache.get_redis", AsyncMock(return_value=redis)):
             await clear_suggestions(user_id, "casual")
-            key = _cache_key(user_id, "casual")
-            redis.delete.assert_called_once_with(key)
+
+        # SCAN would walk the arq queues sharing this db, so the index set is the only lookup.
+        assert not redis.scan_iter.called
+        redis.smembers.assert_awaited_once_with(_index_key(user_id, "casual"))
+        deleted = set(redis.delete.await_args.args)
+        assert deleted == {
+            _cache_key(user_id, "casual"),
+            _index_key(user_id, "casual"),
+            variant_key,
+        }
+
+    @pytest.mark.asyncio
+    async def test_clear_for_one_base_item_leaves_other_variants(self, user_id, mock_redis):
+        redis, _ = mock_redis
+        item_id = uuid4()
+        key = _cache_key(user_id, "casual", include_items=[item_id])
+
+        with patch("app.services.suggestion_cache.get_redis", AsyncMock(return_value=redis)):
+            await clear_suggestions(user_id, "casual", include_items=[item_id])
+
+        redis.delete.assert_awaited_once_with(key)
+        redis.srem.assert_awaited_once_with(_index_key(user_id, "casual"), key)
 
     @pytest.mark.asyncio
     async def test_has_cached_true(self, user_id, mock_redis):

--- a/frontend/app/dashboard/suggest/page.tsx
+++ b/frontend/app/dashboard/suggest/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Suspense } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { useTranslations } from 'next-intl';
 import {
@@ -31,6 +32,9 @@ import {
   Snowflake,
   CalendarDays,
   CloudLightning,
+  Plus,
+  X,
+  Layers,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -38,12 +42,21 @@ import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
+import { ItemPicker } from '@/components/shared/item-picker';
+import { useItem } from '@/lib/hooks/use-items';
 import { api, ApiError, setAccessToken } from '@/lib/api';
-import { Outfit, SuggestRequest } from '@/lib/types';
+import { Item, Outfit, SuggestRequest } from '@/lib/types';
 import { useOccasions } from '@/lib/hooks/use-translated-constants';
 import { useWeather, Weather } from '@/lib/hooks/use-weather';
 import { usePreferences } from '@/lib/hooks/use-preferences';
@@ -303,93 +316,72 @@ function WeatherOverrideSection({
   );
 }
 
-function OutfitResult({
+function OutfitCard({
   outfit,
-  occasion,
+  baseItemId,
   temperatureUnit,
+  t,
   onAccept,
   onReject,
-  onTryAnother,
-  onNewRequest,
-  t,
+  showActions = true,
+  badgeLabel,
 }: {
   outfit: Outfit;
-  occasion: string;
+  baseItemId?: string;
   temperatureUnit: TempUnit;
-  onAccept: () => void;
-  onReject: () => void;
-  onTryAnother: () => void;
-  onNewRequest: () => void;
   t: Translator;
+  onAccept?: () => void;
+  onReject?: () => void;
+  showActions?: boolean;
+  badgeLabel?: string;
 }) {
   return (
-    <div className="space-y-6">
-      {/* Header with occasion and new request */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Badge variant="secondary" className="capitalize text-sm px-3 py-1">
-            {occasion}
-          </Badge>
-          {outfit.scheduled_for && (
-            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-              <CalendarDays className="h-3 w-3" />
-              {new Date(outfit.scheduled_for + 'T00:00:00').toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })}
-            </span>
+    <Card className="overflow-hidden flex flex-col h-full">
+      <div className="bg-gradient-to-r from-primary/10 to-primary/5 p-4 border-b">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 min-w-0">
+            <Sparkles className="h-5 w-5 text-primary flex-shrink-0" />
+            <h3 className="font-semibold text-base truncate">
+              {outfit.reasoning || (badgeLabel ?? t('yourOutfit'))}
+            </h3>
+          </div>
+          {badgeLabel && (
+            <Badge variant="secondary" className="text-xs px-2 py-0.5 flex-shrink-0">
+              {badgeLabel}
+            </Badge>
           )}
         </div>
-        <Button variant="ghost" size="sm" onClick={onNewRequest}>
-          {t('startOver')}
-        </Button>
+        {outfit.highlights && outfit.highlights.length > 0 && (
+          <ul className="mt-2.5 space-y-1">
+            {outfit.highlights.map((highlight, index) => (
+              <li key={index} className="flex items-start gap-2 text-xs sm:text-sm text-muted-foreground">
+                <span className="text-primary mt-0.5">•</span>
+                <span>{highlight}</span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
 
-      {/* Weather info */}
-      {outfit.weather && (
-        <div className="flex items-center gap-4 text-sm text-muted-foreground p-3 rounded-lg bg-muted/50">
-          <div className="flex items-center gap-1.5">
-            <Thermometer className="h-4 w-4" />
-            <span>{formatTemp(outfit.weather.temperature, temperatureUnit)}</span>
-            <span className="text-xs opacity-70">{t('weather.feelsLikeInline', { temp: displayValue(outfit.weather.feels_like, temperatureUnit) })}</span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <Droplets className="h-4 w-4" />
-            <span>{t('weather.rainChance', { chance: outfit.weather.precipitation_chance })}</span>
-          </div>
-          <Badge variant="outline" className="capitalize">
-            {outfit.weather.condition}
-          </Badge>
-        </div>
-      )}
-
-      {/* Outfit Card */}
-      <Card className="overflow-hidden">
-        <div className="bg-gradient-to-r from-primary/10 to-primary/5 p-4 border-b">
-          <div className="flex items-center gap-2">
-            <Sparkles className="h-5 w-5 text-primary" />
-            <h3 className="font-semibold">{t('yourOutfit')}</h3>
-          </div>
-          {outfit.reasoning && (
-            <p className="mt-2 text-base font-medium text-foreground">{outfit.reasoning}</p>
-          )}
-          {outfit.highlights && outfit.highlights.length > 0 && (
-            <ul className="mt-3 space-y-1.5">
-              {outfit.highlights.map((highlight, index) => (
-                <li key={index} className="flex items-start gap-2 text-sm text-muted-foreground">
-                  <span className="text-primary mt-0.5">•</span>
-                  <span>{highlight}</span>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-        <CardContent className="p-4">
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            {outfit.items.map((item) => (
+      <CardContent className="p-4 flex-1 flex flex-col justify-between space-y-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2.5">
+          {outfit.items.map((item) => {
+            const isBase = !!baseItemId && item.id === baseItemId;
+            return (
               <Link
                 key={item.id}
                 href={`/dashboard/wardrobe?item=${item.id}`}
-                className="group relative rounded-xl border overflow-hidden bg-muted/30 hover:shadow-md transition-shadow"
+                className={cn(
+                  'group relative rounded-xl border overflow-hidden bg-muted/30 hover:shadow-md transition-all',
+                  isBase && 'border-primary/60 ring-2 ring-primary/20'
+                )}
               >
                 <div className="aspect-square relative">
+                  {isBase && (
+                    <Badge className="absolute top-2 left-2 z-10 bg-primary/95 text-primary-foreground text-[10px] px-2 py-0.5 shadow-sm">
+                      {t('baseItem.basePiece')}
+                    </Badge>
+                  )}
                   {item.thumbnail_url ? (
                     <Image
                       src={item.thumbnail_url}
@@ -400,54 +392,226 @@ function OutfitResult({
                     />
                   ) : (
                     <div className="w-full h-full flex items-center justify-center bg-muted">
-                      <Shirt className="h-10 w-10 text-muted-foreground/50" />
+                      <Shirt className="h-8 w-8 text-muted-foreground/50" />
                     </div>
                   )}
                 </div>
-                <div className="p-2.5">
-                  <p className="text-sm font-medium truncate">
+                <div className="p-2">
+                  <p className="text-xs sm:text-sm font-medium truncate">
                     {item.name || item.type}
                   </p>
                   {item.layer_type && (
-                    <Badge variant="secondary" className="text-xs capitalize mt-1">
+                    <Badge variant="secondary" className="text-[10px] capitalize mt-0.5">
                       {item.layer_type}
                     </Badge>
                   )}
                 </div>
               </Link>
+            );
+          })}
+        </div>
+
+        {outfit.style_notes && (
+          <div className="p-2.5 bg-muted/60 rounded-lg border text-xs text-muted-foreground">
+            <span className="font-semibold text-foreground">{t('tip')}</span> {outfit.style_notes}
+          </div>
+        )}
+
+        {showActions && (
+          <div className="pt-2 flex gap-2 justify-end border-t mt-auto">
+            {onReject && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onReject}
+                className="h-8 px-2.5 text-muted-foreground hover:text-destructive"
+                aria-label={t('dismissOutfit')}
+              >
+                <ThumbsDown className="h-4 w-4" />
+              </Button>
+            )}
+            {onAccept && (
+              <Button size="sm" onClick={onAccept} className="gap-1.5 text-xs h-8">
+                <ThumbsUp className="h-3.5 w-3.5" />
+                {t('options.chooseThis')}
+              </Button>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function OutfitResultsView({
+  outfits,
+  occasion,
+  temperatureUnit,
+  baseItemId,
+  activeOptionIndex,
+  onSelectOption,
+  isCompareAll,
+  onToggleCompareAll,
+  onAccept,
+  onReject,
+  onTryAnother,
+  onNewRequest,
+  t,
+}: {
+  outfits: Outfit[];
+  occasion: string;
+  temperatureUnit: TempUnit;
+  baseItemId?: string;
+  activeOptionIndex: number;
+  onSelectOption: (index: number) => void;
+  isCompareAll: boolean;
+  onToggleCompareAll: () => void;
+  onAccept: (outfit?: Outfit) => void;
+  onReject: (outfit?: Outfit) => void;
+  onTryAnother: () => void;
+  onNewRequest: () => void;
+  t: Translator;
+}) {
+  const currentOutfit = outfits[activeOptionIndex] || outfits[0];
+
+  return (
+    <div className="space-y-6">
+      {/* Header with occasion and start over */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary" className="capitalize text-sm px-3 py-1">
+            {occasion}
+          </Badge>
+          {currentOutfit?.scheduled_for && (
+            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+              <CalendarDays className="h-3 w-3" />
+              {new Date(currentOutfit.scheduled_for + 'T00:00:00').toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })}
+            </span>
+          )}
+        </div>
+        <Button variant="ghost" size="sm" onClick={onNewRequest}>
+          {t('startOver')}
+        </Button>
+      </div>
+
+      {/* Weather info */}
+      {currentOutfit?.weather && (
+        <div className="flex items-center gap-4 text-sm text-muted-foreground p-3 rounded-lg bg-muted/50">
+          <div className="flex items-center gap-1.5">
+            <Thermometer className="h-4 w-4" />
+            <span>{formatTemp(currentOutfit.weather.temperature, temperatureUnit)}</span>
+            <span className="text-xs opacity-70">{t('weather.feelsLikeInline', { temp: displayValue(currentOutfit.weather.feels_like, temperatureUnit) })}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Droplets className="h-4 w-4" />
+            <span>{t('weather.rainChance', { chance: currentOutfit.weather.precipitation_chance })}</span>
+          </div>
+          <Badge variant="outline" className="capitalize">
+            {currentOutfit.weather.condition}
+          </Badge>
+        </div>
+      )}
+
+      {/* Options Switcher Bar (when multiple outfits exist) */}
+      {outfits.length > 1 && (
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 p-1.5 bg-muted/60 rounded-xl border">
+          <div className="flex items-center gap-1.5 overflow-x-auto scrollbar-none py-0.5">
+            {outfits.map((opt, idx) => (
+              <button
+                key={opt.id}
+                type="button"
+                onClick={() => onSelectOption(idx)}
+                className={cn(
+                  'px-3 py-1.5 rounded-lg text-xs sm:text-sm font-medium transition-all flex items-center gap-1.5 flex-shrink-0',
+                  !isCompareAll && activeOptionIndex === idx
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-background/50'
+                )}
+              >
+                <Sparkles className={cn("h-3.5 w-3.5", !isCompareAll && activeOptionIndex === idx ? "text-primary" : "opacity-40")} />
+                <span>{t('options.optionNumber', { number: idx + 1 })}</span>
+              </button>
             ))}
           </div>
 
-          {outfit.style_notes && (
-            <div className="mt-4 p-3 bg-muted rounded-lg border">
-              <p className="text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">{t('tip')}</span> {outfit.style_notes}
-              </p>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+          <div className="flex items-center gap-1 pt-1.5 sm:pt-0 border-t sm:border-t-0 justify-end">
+            <Button
+              variant={isCompareAll ? 'default' : 'ghost'}
+              size="sm"
+              className="h-7 text-xs gap-1.5"
+              onClick={onToggleCompareAll}
+            >
+              <Layers className="h-3.5 w-3.5" />
+              <span>{isCompareAll ? t('options.singleView') : t('options.allOptions')}</span>
+            </Button>
+          </div>
+        </div>
+      )}
 
-      {/* Action buttons */}
-      <div className="flex gap-3 justify-center">
-        <Button variant="outline" size="lg" onClick={onTryAnother} className="gap-2">
-          <RefreshCw className="h-4 w-4" />
-          {t('tryAnother')}
-        </Button>
-        <Button size="lg" onClick={onAccept} className="gap-2">
-          <ThumbsUp className="h-4 w-4" />
-          {t('loveIt')}
-        </Button>
-        <Button variant="ghost" size="lg" onClick={onReject} className="px-3" aria-label={t('dismissOutfit')}>
-          <ThumbsDown className="h-4 w-4" />
-        </Button>
-      </div>
+      {/* View: All Outfits Side-by-Side Grid */}
+      {isCompareAll ? (
+        <div className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {outfits.map((opt, idx) => (
+              <OutfitCard
+                key={opt.id}
+                outfit={opt}
+                baseItemId={baseItemId}
+                temperatureUnit={temperatureUnit}
+                t={t}
+                badgeLabel={t('options.optionNumber', { number: idx + 1 })}
+                onAccept={() => onAccept(opt)}
+                onReject={() => onReject(opt)}
+                showActions={true}
+              />
+            ))}
+          </div>
+          <div className="flex gap-3 justify-center pt-2">
+            <Button variant="outline" size="lg" onClick={onTryAnother} className="gap-2">
+              <RefreshCw className="h-4 w-4" />
+              {t('options.generateNew')}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        /* View: Single Active Outfit Focus */
+        <div className="space-y-6">
+          <OutfitCard
+            outfit={currentOutfit}
+            baseItemId={baseItemId}
+            temperatureUnit={temperatureUnit}
+            t={t}
+            badgeLabel={outfits.length > 1 ? t('options.optionNumber', { number: activeOptionIndex + 1 }) : undefined}
+            onAccept={() => onAccept(currentOutfit)}
+            onReject={() => onReject(currentOutfit)}
+            showActions={false}
+          />
+
+          {/* Action buttons */}
+          <div className="flex gap-3 justify-center">
+            <Button variant="outline" size="lg" onClick={onTryAnother} className="gap-2">
+              <RefreshCw className="h-4 w-4" />
+              {outfits.length > 1 ? t('options.generateNew') : t('tryAnother')}
+            </Button>
+            <Button size="lg" onClick={() => onAccept(currentOutfit)} className="gap-2">
+              <ThumbsUp className="h-4 w-4" />
+              {t('loveIt')}
+            </Button>
+            <Button variant="ghost" size="lg" onClick={() => onReject(currentOutfit)} className="px-3" aria-label={t('dismissOutfit')}>
+              <ThumbsDown className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
 
-export default function SuggestPage() {
+function SuggestContent() {
   const t = useTranslations('suggest');
+  const searchParams = useSearchParams();
+  const preselectedItemId = searchParams.get('item');
+  const { data: preselectedItem } = useItem(preselectedItemId || '');
   const { data: session } = useSession();
   const { data: weather, isLoading: weatherLoading } = useWeather();
   const { data: prefs } = usePreferences();
@@ -455,9 +619,20 @@ export default function SuggestPage() {
   const [selectedOccasion, setSelectedOccasion] = useState<string | null>(null);
   const [occasionInitialized, setOccasionInitialized] = useState(false);
   const [weatherOverride, setWeatherOverride] = useState<WeatherOverride | null>(null);
+  const [selectedItem, setSelectedItem] = useState<Item | null>(null);
+  const [isItemPickerOpen, setIsItemPickerOpen] = useState(false);
+  const [filterType, setFilterType] = useState<string | undefined>(undefined);
   const [isGenerating, setIsGenerating] = useState(false);
-  const [outfit, setOutfit] = useState<Outfit | null>(null);
+  const [outfits, setOutfits] = useState<Outfit[]>([]);
+  const [activeOptionIndex, setActiveOptionIndex] = useState<number>(0);
+  const [isCompareAll, setIsCompareAll] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (preselectedItem && !selectedItem) {
+      setSelectedItem(preselectedItem);
+    }
+  }, [preselectedItem, selectedItem]);
 
   useEffect(() => {
     if (prefs?.default_occasion && !occasionInitialized && !selectedOccasion) {
@@ -479,6 +654,7 @@ export default function SuggestPage() {
     try {
       const request: SuggestRequest = {
         occasion: selectedOccasion,
+        include_items: selectedItem ? [selectedItem.id] : [],
       };
 
       if (weatherOverride) {
@@ -491,8 +667,9 @@ export default function SuggestPage() {
         };
       }
 
-      const result = await api.post<Outfit>('/outfits/suggest', request);
-      setOutfit(result);
+      const result = await api.post<Outfit[]>('/outfits/suggest-options', request);
+      setOutfits(result);
+      setActiveOptionIndex(0);
     } catch (err) {
       if (err instanceof ApiError) {
         setError(err.message);
@@ -505,16 +682,17 @@ export default function SuggestPage() {
     }
   };
 
-  const handleAccept = async () => {
-    if (!outfit) return;
+  const handleAccept = async (targetOutfit?: Outfit) => {
+    const outfitToAccept = targetOutfit || outfits[activeOptionIndex];
+    if (!outfitToAccept) return;
 
     if (session?.accessToken) {
       setAccessToken(session.accessToken as string);
     }
 
     try {
-      await api.post(`/outfits/${outfit.id}/accept`);
-      setOutfit(null);
+      await api.post(`/outfits/${outfitToAccept.id}/accept`);
+      setOutfits([]);
       setSelectedOccasion(null);
     } catch (err) {
       console.error('Accept error:', err);
@@ -522,35 +700,49 @@ export default function SuggestPage() {
   };
 
   const handleTryAnother = () => {
-    setOutfit(null);
+    setOutfits([]);
     handleGenerate();
   };
 
-  const handleReject = async () => {
-    if (!outfit) return;
+  const handleReject = async (targetOutfit?: Outfit) => {
+    const outfitToReject = targetOutfit || outfits[activeOptionIndex];
+    if (!outfitToReject) return;
 
     if (session?.accessToken) {
       setAccessToken(session.accessToken as string);
     }
 
     try {
-      await api.post(`/outfits/${outfit.id}/reject`);
+      await api.post(`/outfits/${outfitToReject.id}/reject`);
     } catch (err) {
       console.error('Reject error:', err);
     }
 
-    setOutfit(null);
-    handleGenerate();
+    const remaining = outfits.filter((o) => o.id !== outfitToReject.id);
+    if (remaining.length > 0) {
+      setOutfits(remaining);
+      setActiveOptionIndex((prev) => Math.min(prev, remaining.length - 1));
+    } else {
+      setOutfits([]);
+      handleGenerate();
+    }
   };
 
   const handleNewRequest = () => {
-    setOutfit(null);
+    setOutfits([]);
+    setActiveOptionIndex(0);
+    setIsCompareAll(false);
     setSelectedOccasion(null);
     setError(null);
   };
 
   return (
-    <div className="max-w-2xl mx-auto space-y-6">
+    <div
+      className={cn(
+        "mx-auto space-y-6 transition-all duration-300",
+        isCompareAll && outfits.length > 0 ? "max-w-5xl" : "max-w-2xl"
+      )}
+    >
       {/* Page header with greeting */}
       <div className="text-center space-y-1">
         <h1 className="text-2xl font-bold tracking-tight">{t(getGreetingKey())}</h1>
@@ -566,7 +758,7 @@ export default function SuggestPage() {
         </Alert>
       )}
 
-      {!outfit ? (
+      {outfits.length === 0 ? (
         <div className="space-y-6">
           {/* Weather context */}
           <WeatherCard weather={weather} isLoading={weatherLoading} temperatureUnit={temperatureUnit} t={t} />
@@ -581,6 +773,99 @@ export default function SuggestPage() {
                   selected={selectedOccasion}
                   onSelect={setSelectedOccasion}
                 />
+              </div>
+
+              {/* Base item selection */}
+              <div className="space-y-3 pt-1 border-t">
+                <div className="space-y-0.5">
+                  <h2 className="font-semibold text-sm sm:text-base flex items-center gap-2">
+                    <Sparkles className="h-4 w-4 text-primary" />
+                    {t('baseItem.title')}
+                  </h2>
+                  <p className="text-xs text-muted-foreground">
+                    {t('baseItem.subtitle')}
+                  </p>
+                </div>
+
+                {!selectedItem ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-full h-16 border-dashed border-2 flex items-center justify-center gap-3 hover:border-primary/60 hover:bg-primary/5 transition-all text-muted-foreground hover:text-foreground"
+                    onClick={() => setIsItemPickerOpen(true)}
+                  >
+                    <div className="p-2 rounded-full bg-muted">
+                      <Plus className="h-4 w-4" />
+                    </div>
+                    <div className="text-left">
+                      <span className="text-sm font-medium block text-foreground">
+                        {t('baseItem.chooseItem')}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {t('baseItem.chooseItemHint')}
+                      </span>
+                    </div>
+                  </Button>
+                ) : (
+                  <div className="flex items-center justify-between p-3 rounded-xl border bg-card/80 shadow-sm gap-3">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className="relative w-14 h-14 rounded-lg overflow-hidden border bg-muted flex-shrink-0">
+                        {selectedItem.thumbnail_url || selectedItem.image_url ? (
+                          <Image
+                            src={(selectedItem.thumbnail_url || selectedItem.image_url)!}
+                            alt={selectedItem.name || selectedItem.type}
+                            fill
+                            className="object-cover"
+                            sizes="56px"
+                          />
+                        ) : (
+                          <div className="w-full h-full flex items-center justify-center bg-muted">
+                            <Shirt className="h-6 w-6 text-muted-foreground" />
+                          </div>
+                        )}
+                      </div>
+                      <div className="min-w-0 space-y-1">
+                        <div className="flex items-center gap-2">
+                          <Badge variant="default" className="text-[10px] px-1.5 py-0">
+                            {t('baseItem.mustInclude')}
+                          </Badge>
+                          <Badge variant="secondary" className="text-[10px] capitalize px-1.5 py-0">
+                            {selectedItem.type}
+                          </Badge>
+                        </div>
+                        <p className="text-sm font-medium truncate">
+                          {selectedItem.name || selectedItem.type}
+                        </p>
+                        {selectedItem.primary_color && (
+                          <p className="text-xs text-muted-foreground capitalize truncate">
+                            {selectedItem.primary_color}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1 flex-shrink-0">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setIsItemPickerOpen(true)}
+                        className="text-xs"
+                      >
+                        {t('baseItem.change')}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setSelectedItem(null)}
+                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                        title={t('baseItem.remove')}
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                )}
               </div>
 
               {/* Weather override (collapsible) */}
@@ -616,10 +901,15 @@ export default function SuggestPage() {
           </Card>
         </div>
       ) : (
-        <OutfitResult
-          outfit={outfit}
+        <OutfitResultsView
+          outfits={outfits}
+          activeOptionIndex={activeOptionIndex}
+          onSelectOption={setActiveOptionIndex}
+          isCompareAll={isCompareAll}
+          onToggleCompareAll={() => setIsCompareAll(!isCompareAll)}
           occasion={selectedOccasion || 'casual'}
           temperatureUnit={temperatureUnit}
+          baseItemId={selectedItem?.id}
           onAccept={handleAccept}
           onReject={handleReject}
           onTryAnother={handleTryAnother}
@@ -627,6 +917,110 @@ export default function SuggestPage() {
           t={t}
         />
       )}
+
+      {/* Item Picker Dialog */}
+      <Dialog open={isItemPickerOpen} onOpenChange={setIsItemPickerOpen}>
+        <DialogContent className="sm:max-w-xl max-h-[85vh] flex flex-col p-6">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Sparkles className="h-5 w-5 text-primary" />
+              {t('baseItem.dialogTitle')}
+            </DialogTitle>
+            <DialogDescription>
+              {t('baseItem.dialogDescription')}
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* Quick Category Filter Chips */}
+          <div className="flex gap-1.5 overflow-x-auto py-1 scrollbar-none">
+            {[
+              { label: t('baseItem.all'), value: undefined },
+              { label: 'Shirt', value: 'shirt' },
+              { label: 'T-Shirt', value: 't-shirt' },
+              { label: 'Pants', value: 'pants' },
+              { label: 'Jeans', value: 'jeans' },
+              { label: 'Shoes', value: 'shoes' },
+              { label: 'Sneakers', value: 'sneakers' },
+              { label: 'Jacket', value: 'jacket' },
+              { label: 'Dress', value: 'dress' },
+            ].map((cat) => (
+              <Button
+                key={cat.value ?? 'all'}
+                type="button"
+                variant={filterType === cat.value ? 'default' : 'outline'}
+                size="sm"
+                className="text-xs h-7 px-2.5 rounded-full flex-shrink-0"
+                onClick={() => setFilterType(cat.value)}
+              >
+                {cat.label}
+              </Button>
+            ))}
+          </div>
+
+          <div className="flex-1 overflow-hidden min-h-0 pt-1">
+            <ItemPicker
+              key={filterType ?? 'all'}
+              selectedIds={selectedItem ? new Set([selectedItem.id]) : new Set()}
+              onToggle={(item) => {
+                if (selectedItem?.id === item.id) {
+                  setSelectedItem(null);
+                } else {
+                  setSelectedItem(item);
+                  setIsItemPickerOpen(false);
+                }
+              }}
+              filterType={filterType}
+              hideNeedsWash={true}
+              heightClass="h-[340px]"
+            />
+          </div>
+
+          <div className="flex justify-between items-center pt-3 border-t mt-2">
+            {selectedItem ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setSelectedItem(null)}
+                className="text-xs text-muted-foreground hover:text-destructive"
+              >
+                {t('baseItem.clear')}
+              </Button>
+            ) : <div />}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setIsItemPickerOpen(false)}
+            >
+              Done
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
+  );
+}
+
+export default function SuggestPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="max-w-2xl mx-auto space-y-6">
+          <div className="space-y-2 text-center">
+            <Skeleton className="h-8 w-48 mx-auto" />
+            <Skeleton className="h-4 w-64 mx-auto" />
+          </div>
+          <Card>
+            <CardContent className="p-6 space-y-4">
+              <Skeleton className="h-24 w-full rounded-lg" />
+              <Skeleton className="h-10 w-full" />
+            </CardContent>
+          </Card>
+        </div>
+      }
+    >
+      <SuggestContent />
+    </Suspense>
   );
 }

--- a/frontend/app/dashboard/suggest/page.tsx
+++ b/frontend/app/dashboard/suggest/page.tsx
@@ -607,8 +607,19 @@ function OutfitResultsView({
   );
 }
 
+// suggest-options materialises all three looks up front, so any the user walks away from
+// would otherwise sit in history as pending forever.
+async function discardAlternatives(outfits: Outfit[], keepId?: string) {
+  await Promise.allSettled(
+    outfits
+      .filter((o) => o.id !== keepId)
+      .map((o) => api.post(`/outfits/${o.id}/skip`))
+  );
+}
+
 function SuggestContent() {
   const t = useTranslations('suggest');
+  const tCommon = useTranslations('common');
   const searchParams = useSearchParams();
   const preselectedItemId = searchParams.get('item');
   const { data: preselectedItem } = useItem(preselectedItemId || '');
@@ -692,6 +703,10 @@ function SuggestContent() {
 
     try {
       await api.post(`/outfits/${outfitToAccept.id}/accept`);
+      // Every look was already persisted, so the ones left over are marked skipped rather
+      // than rejected: rejecting would auto-exclude their items from today's suggestions,
+      // and those items mostly overlap with the outfit just accepted.
+      await discardAlternatives(outfits, outfitToAccept.id);
       setOutfits([]);
       setSelectedOccasion(null);
     } catch (err) {
@@ -699,7 +714,8 @@ function SuggestContent() {
     }
   };
 
-  const handleTryAnother = () => {
+  const handleTryAnother = async () => {
+    await discardAlternatives(outfits);
     setOutfits([]);
     handleGenerate();
   };
@@ -728,7 +744,8 @@ function SuggestContent() {
     }
   };
 
-  const handleNewRequest = () => {
+  const handleNewRequest = async () => {
+    await discardAlternatives(outfits);
     setOutfits([]);
     setActiveOptionIndex(0);
     setIsCompareAll(false);
@@ -993,7 +1010,7 @@ function SuggestContent() {
               size="sm"
               onClick={() => setIsItemPickerOpen(false)}
             >
-              Done
+              {tCommon('done')}
             </Button>
           </div>
         </DialogContent>

--- a/frontend/components/item-detail-dialog.tsx
+++ b/frontend/components/item-detail-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import {
   Heart,
   Pencil,
@@ -79,6 +80,7 @@ export function ItemDetailDialog({ item, open, onOpenChange }: ItemDetailDialogP
   const t = useTranslations('wardrobe.itemDetail');
   const tc = useTranslations('common');
   const tw = useTranslations('wardrobe');
+  const router = useRouter();
   const clothingTypes = useClothingTypes();
   const clothingColors = useClothingColors();
   const [isEditing, setIsEditing] = useState(false);
@@ -268,157 +270,154 @@ export function ItemDetailDialog({ item, open, onOpenChange }: ItemDetailDialogP
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="sm:max-w-2xl max-h-[90vh] flex flex-col p-0 overflow-hidden [&>button]:hidden">
           {/* Header - sticky */}
-          <DialogHeader className="flex flex-row items-center gap-2 space-y-0 p-4 border-b flex-shrink-0">
-            {/* Capped on narrow screens because the title claims its content
-                width before the actions do, and a long item name otherwise
-                squeezes the scrollable row down to about one button. */}
-            <DialogTitle className="text-xl min-w-0 truncate max-w-[45%] sm:max-w-none">
+          <DialogHeader className="flex flex-row items-center justify-between space-y-0 p-4 border-b flex-shrink-0">
+            <DialogTitle className="text-xl min-w-0 truncate">
               {item.name || (typeInfo ? typeInfo.label : item.type)}
             </DialogTitle>
-            {/* The action row scrolls sideways once it stops fitting, because
-                the dialog clips its own overflow: without this the buttons
-                push the close control past the right edge on a phone and it
-                cannot be reached at all. */}
-            <div className="flex-1 min-w-0 overflow-x-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-              <div className="flex w-max ml-auto items-center gap-1">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleToggleFavorite}
-                  disabled={updateItem.isPending}
-                  title={t('titles.toggleFavorite')}
-                >
-                  <Heart
-                    className={`h-5 w-5 ${
-                      item.favorite ? 'fill-red-500 text-red-500' : 'text-muted-foreground'
-                    }`}
-                  />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => setShowPairingsDialog(true)}
-                  disabled={item.status !== 'ready'}
-                  title={t('titles.findMatchingOutfits')}
-                >
-                  <Layers className="h-5 w-5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleReanalyze}
-                  disabled={isAnalyzing}
-                  title={isAnalyzing ? t('titles.analysisInProgress') : t('titles.reanalyzeWithAI')}
-                >
-                  <RefreshCw
-                    className={`h-5 w-5 ${isAnalyzing ? 'animate-spin text-primary' : ''}`}
-                  />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => handleRotate('ccw')}
-                  disabled={rotateImage.isPending}
-                  title={t('titles.rotateLeft')}
-                >
-                  {rotateImage.isPending ? (
-                    <Loader2 className="h-5 w-5 animate-spin" />
-                  ) : (
-                    <RotateCcw className="h-5 w-5" />
-                  )}
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => handleRotate('cw')}
-                  disabled={rotateImage.isPending}
-                  title={t('titles.rotateRight')}
-                >
-                  {rotateImage.isPending ? (
-                    <Loader2 className="h-5 w-5 animate-spin" />
-                  ) : (
-                    <RotateCw className="h-5 w-5" />
-                  )}
-                </Button>
-                {features?.background_removal && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={handleRemoveBackground}
-                    disabled={removeBackground.isPending || !item.image_url}
-                    title={t('titles.removeBackground')}
-                  >
-                    {removeBackground.isPending ? (
-                      <Loader2 className="h-5 w-5 animate-spin" />
-                    ) : (
-                      <Eraser className="h-5 w-5" />
-                    )}
-                  </Button>
-                )}
-                {item.original_image_path && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={handleRestoreOriginal}
-                    disabled={restoreOriginal.isPending}
-                    title={t('titles.undoBackgroundRemoval')}
-                  >
-                    {restoreOriginal.isPending ? (
-                      <Loader2 className="h-5 w-5 animate-spin" />
-                    ) : (
-                      <Undo2 className="h-5 w-5" />
-                    )}
-                  </Button>
-                )}
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => replaceImageInputRef.current?.click()}
-                  disabled={replaceImage.isPending}
-                  title={t('titles.replaceImage')}
-                >
-                  {replaceImage.isPending ? (
-                    <Loader2 className="h-5 w-5 animate-spin" />
-                  ) : (
-                    <ImagePlus className="h-5 w-5" />
-                  )}
-                </Button>
-                <input
-                  ref={replaceImageInputRef}
-                  type="file"
-                  accept="image/*"
-                  className="hidden"
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) {
-                      handleReplaceImage(file);
-                    }
-                    e.target.value = '';
-                  }}
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleToggleFavorite}
+                disabled={updateItem.isPending}
+                title={t('titles.toggleFavorite')}
+              >
+                <Heart
+                  className={`h-5 w-5 ${
+                    item.favorite ? 'fill-red-500 text-red-500' : 'text-muted-foreground'
+                  }`}
                 />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setShowPairingsDialog(true)}
+                disabled={item.status !== 'ready'}
+                title={t('titles.findMatchingOutfits')}
+              >
+                <Layers className="h-5 w-5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => {
+                  onOpenChange(false);
+                  router.push(`/dashboard/suggest?item=${item.id}`);
+                }}
+                disabled={item.status !== 'ready'}
+                title={t('titles.suggestOutfit')}
+              >
+                <Sparkles className="h-5 w-5 text-primary" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleReanalyze}
+                disabled={isAnalyzing}
+                title={isAnalyzing ? t('titles.analysisInProgress') : t('titles.reanalyzeWithAI')}
+              >
+                <RefreshCw
+                  className={`h-5 w-5 ${isAnalyzing ? 'animate-spin text-primary' : ''}`}
+                />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => handleRotate('ccw')}
+                disabled={rotateImage.isPending}
+                title={t('titles.rotateLeft')}
+              >
+                {rotateImage.isPending ? (
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                ) : (
+                  <RotateCcw className="h-5 w-5" />
+                )}
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => handleRotate('cw')}
+                disabled={rotateImage.isPending}
+                title={t('titles.rotateRight')}
+              >
+                {rotateImage.isPending ? (
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                ) : (
+                  <RotateCw className="h-5 w-5" />
+                )}
+              </Button>
+              {features?.background_removal && (
                 <Button
                   variant="ghost"
                   size="icon"
-                  onClick={() => setIsEditing(!isEditing)}
-                  title={isEditing ? t('actions.cancelEditing') : t('actions.editItem')}
+                  onClick={handleRemoveBackground}
+                  disabled={removeBackground.isPending || !item.image_url}
+                  title={t('titles.removeBackground')}
                 >
-                  {isEditing ? (
-                    <X className="h-5 w-5" />
+                  {removeBackground.isPending ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
                   ) : (
-                    <Pencil className="h-5 w-5" />
+                    <Eraser className="h-5 w-5" />
                   )}
                 </Button>
-              </div>
+              )}
+              {item.original_image_path && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleRestoreOriginal}
+                  disabled={restoreOriginal.isPending}
+                  title={t('titles.undoBackgroundRemoval')}
+                >
+                  {restoreOriginal.isPending ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  ) : (
+                    <Undo2 className="h-5 w-5" />
+                  )}
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => replaceImageInputRef.current?.click()}
+                disabled={replaceImage.isPending}
+                title={t('titles.replaceImage')}
+              >
+                {replaceImage.isPending ? (
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                ) : (
+                  <ImagePlus className="h-5 w-5" />
+                )}
+              </Button>
+              <input
+                ref={replaceImageInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) {
+                    handleReplaceImage(file);
+                  }
+                  e.target.value = '';
+                }}
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setIsEditing(!isEditing)}
+                title={isEditing ? t('actions.cancelEditing') : t('actions.editItem')}
+              >
+                {isEditing ? (
+                  <X className="h-5 w-5" />
+                ) : (
+                  <Pencil className="h-5 w-5" />
+                )}
+              </Button>
+              <Button variant="ghost" size="icon" onClick={() => onOpenChange(false)} className="rounded-full" title={tc('close')}>
+                <X className="h-5 w-5" />
+              </Button>
             </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => onOpenChange(false)}
-              className="rounded-full flex-shrink-0"
-              title={tc('close')}
-            >
-              <X className="h-5 w-5" />
-            </Button>
           </DialogHeader>
 
           {/* Scrollable content */}

--- a/frontend/components/item-detail-dialog.tsx
+++ b/frontend/components/item-detail-dialog.tsx
@@ -270,154 +270,169 @@ export function ItemDetailDialog({ item, open, onOpenChange }: ItemDetailDialogP
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="sm:max-w-2xl max-h-[90vh] flex flex-col p-0 overflow-hidden [&>button]:hidden">
           {/* Header - sticky */}
-          <DialogHeader className="flex flex-row items-center justify-between space-y-0 p-4 border-b flex-shrink-0">
-            <DialogTitle className="text-xl min-w-0 truncate">
+          <DialogHeader className="flex flex-row items-center gap-2 space-y-0 p-4 border-b flex-shrink-0">
+            {/* Capped on narrow screens because the title claims its content
+                width before the actions do, and a long item name otherwise
+                squeezes the scrollable row down to about one button. */}
+            <DialogTitle className="text-xl min-w-0 truncate max-w-[45%] sm:max-w-none">
               {item.name || (typeInfo ? typeInfo.label : item.type)}
             </DialogTitle>
-            <div className="flex items-center gap-1">
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleToggleFavorite}
-                disabled={updateItem.isPending}
-                title={t('titles.toggleFavorite')}
-              >
-                <Heart
-                  className={`h-5 w-5 ${
-                    item.favorite ? 'fill-red-500 text-red-500' : 'text-muted-foreground'
-                  }`}
-                />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => setShowPairingsDialog(true)}
-                disabled={item.status !== 'ready'}
-                title={t('titles.findMatchingOutfits')}
-              >
-                <Layers className="h-5 w-5" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => {
-                  onOpenChange(false);
-                  router.push(`/dashboard/suggest?item=${item.id}`);
-                }}
-                disabled={item.status !== 'ready'}
-                title={t('titles.suggestOutfit')}
-              >
-                <Sparkles className="h-5 w-5 text-primary" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleReanalyze}
-                disabled={isAnalyzing}
-                title={isAnalyzing ? t('titles.analysisInProgress') : t('titles.reanalyzeWithAI')}
-              >
-                <RefreshCw
-                  className={`h-5 w-5 ${isAnalyzing ? 'animate-spin text-primary' : ''}`}
-                />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => handleRotate('ccw')}
-                disabled={rotateImage.isPending}
-                title={t('titles.rotateLeft')}
-              >
-                {rotateImage.isPending ? (
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                ) : (
-                  <RotateCcw className="h-5 w-5" />
-                )}
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => handleRotate('cw')}
-                disabled={rotateImage.isPending}
-                title={t('titles.rotateRight')}
-              >
-                {rotateImage.isPending ? (
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                ) : (
-                  <RotateCw className="h-5 w-5" />
-                )}
-              </Button>
-              {features?.background_removal && (
+            {/* The action row scrolls sideways once it stops fitting, because
+                the dialog clips its own overflow: without this the buttons
+                push the close control past the right edge on a phone and it
+                cannot be reached at all. */}
+            <div className="flex-1 min-w-0 overflow-x-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+              <div className="flex w-max ml-auto items-center gap-1">
                 <Button
                   variant="ghost"
                   size="icon"
-                  onClick={handleRemoveBackground}
-                  disabled={removeBackground.isPending || !item.image_url}
-                  title={t('titles.removeBackground')}
+                  onClick={handleToggleFavorite}
+                  disabled={updateItem.isPending}
+                  title={t('titles.toggleFavorite')}
                 >
-                  {removeBackground.isPending ? (
-                    <Loader2 className="h-5 w-5 animate-spin" />
-                  ) : (
-                    <Eraser className="h-5 w-5" />
-                  )}
+                  <Heart
+                    className={`h-5 w-5 ${
+                      item.favorite ? 'fill-red-500 text-red-500' : 'text-muted-foreground'
+                    }`}
+                  />
                 </Button>
-              )}
-              {item.original_image_path && (
                 <Button
                   variant="ghost"
                   size="icon"
-                  onClick={handleRestoreOriginal}
-                  disabled={restoreOriginal.isPending}
-                  title={t('titles.undoBackgroundRemoval')}
+                  onClick={() => setShowPairingsDialog(true)}
+                  disabled={item.status !== 'ready'}
+                  title={t('titles.findMatchingOutfits')}
                 >
-                  {restoreOriginal.isPending ? (
+                  <Layers className="h-5 w-5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => {
+                    onOpenChange(false);
+                    router.push(`/dashboard/suggest?item=${item.id}`);
+                  }}
+                  disabled={item.status !== 'ready'}
+                  title={t('titles.suggestOutfit')}
+                >
+                  <Sparkles className="h-5 w-5 text-primary" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleReanalyze}
+                  disabled={isAnalyzing}
+                  title={isAnalyzing ? t('titles.analysisInProgress') : t('titles.reanalyzeWithAI')}
+                >
+                  <RefreshCw
+                    className={`h-5 w-5 ${isAnalyzing ? 'animate-spin text-primary' : ''}`}
+                  />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleRotate('ccw')}
+                  disabled={rotateImage.isPending}
+                  title={t('titles.rotateLeft')}
+                >
+                  {rotateImage.isPending ? (
                     <Loader2 className="h-5 w-5 animate-spin" />
                   ) : (
-                    <Undo2 className="h-5 w-5" />
+                    <RotateCcw className="h-5 w-5" />
                   )}
                 </Button>
-              )}
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => replaceImageInputRef.current?.click()}
-                disabled={replaceImage.isPending}
-                title={t('titles.replaceImage')}
-              >
-                {replaceImage.isPending ? (
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                ) : (
-                  <ImagePlus className="h-5 w-5" />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleRotate('cw')}
+                  disabled={rotateImage.isPending}
+                  title={t('titles.rotateRight')}
+                >
+                  {rotateImage.isPending ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  ) : (
+                    <RotateCw className="h-5 w-5" />
+                  )}
+                </Button>
+                {features?.background_removal && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={handleRemoveBackground}
+                    disabled={removeBackground.isPending || !item.image_url}
+                    title={t('titles.removeBackground')}
+                  >
+                    {removeBackground.isPending ? (
+                      <Loader2 className="h-5 w-5 animate-spin" />
+                    ) : (
+                      <Eraser className="h-5 w-5" />
+                    )}
+                  </Button>
                 )}
-              </Button>
-              <input
-                ref={replaceImageInputRef}
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={(e) => {
-                  const file = e.target.files?.[0];
-                  if (file) {
-                    handleReplaceImage(file);
-                  }
-                  e.target.value = '';
-                }}
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => setIsEditing(!isEditing)}
-                title={isEditing ? t('actions.cancelEditing') : t('actions.editItem')}
-              >
-                {isEditing ? (
-                  <X className="h-5 w-5" />
-                ) : (
-                  <Pencil className="h-5 w-5" />
+                {item.original_image_path && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={handleRestoreOriginal}
+                    disabled={restoreOriginal.isPending}
+                    title={t('titles.undoBackgroundRemoval')}
+                  >
+                    {restoreOriginal.isPending ? (
+                      <Loader2 className="h-5 w-5 animate-spin" />
+                    ) : (
+                      <Undo2 className="h-5 w-5" />
+                    )}
+                  </Button>
                 )}
-              </Button>
-              <Button variant="ghost" size="icon" onClick={() => onOpenChange(false)} className="rounded-full" title={tc('close')}>
-                <X className="h-5 w-5" />
-              </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => replaceImageInputRef.current?.click()}
+                  disabled={replaceImage.isPending}
+                  title={t('titles.replaceImage')}
+                >
+                  {replaceImage.isPending ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  ) : (
+                    <ImagePlus className="h-5 w-5" />
+                  )}
+                </Button>
+                <input
+                  ref={replaceImageInputRef}
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) {
+                      handleReplaceImage(file);
+                    }
+                    e.target.value = '';
+                  }}
+                />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setIsEditing(!isEditing)}
+                  title={isEditing ? t('actions.cancelEditing') : t('actions.editItem')}
+                >
+                  {isEditing ? (
+                    <X className="h-5 w-5" />
+                  ) : (
+                    <Pencil className="h-5 w-5" />
+                  )}
+                </Button>
+              </div>
             </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => onOpenChange(false)}
+              className="rounded-full flex-shrink-0"
+              title={tc('close')}
+            >
+              <X className="h-5 w-5" />
+            </Button>
           </DialogHeader>
 
           {/* Scrollable content */}

--- a/frontend/messages/de/suggest.json
+++ b/frontend/messages/de/suggest.json
@@ -1,4 +1,18 @@
 {
+  "baseItem": {
+    "all": "Alle",
+    "basePiece": "Basisteil",
+    "change": "Ändern",
+    "chooseItem": "Kleidungsstück wählen",
+    "chooseItemHint": "Wähle ein Hemd, eine Hose, Schuhe oder ein Teil als Basis",
+    "clear": "Löschen",
+    "dialogDescription": "Wähle ein Kleidungsstück aus deiner Garderobe, um dein Outfit darum aufzubauen.",
+    "dialogTitle": "Kleidungsstück für dein Outfit wählen",
+    "mustInclude": "Muss enthalten sein",
+    "remove": "Entfernen",
+    "subtitle": "Wähle ein Hemd, eine Hose, Schuhe oder ein Teil, das im Outfit vorkommen muss",
+    "title": "Um ein bestimmtes Teil aufbauen (optional)"
+  },
   "dismissOutfit": "Outfit verwerfen",
   "error": "Outfit-Vorschlag konnte nicht generiert werden. Bitte versuche es erneut.",
   "feedback": {
@@ -39,6 +53,14 @@
   },
   "loveIt": "Gefällt mir",
   "occasionPrompt": "Was ist der Anlass?",
+  "options": {
+    "allOptions": "Alle vergleichen",
+    "chooseThis": "Diesen Look wählen",
+    "generateNew": "3 neue Looks generieren",
+    "optionNumber": "Look {number}",
+    "singleView": "Einzelansicht",
+    "title": "{count} Outfit-Optionen"
+  },
   "outfitPreview": {
     "familyRatings": {
       "average": "({rating} <star></star> Ø)",

--- a/frontend/messages/de/wardrobe.json
+++ b/frontend/messages/de/wardrobe.json
@@ -85,10 +85,7 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
-    "rotateFailed": "Rotation failed",
-    "rotateQueued": "Queued for rotation",
-    "rotating": "Rotating…"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
   },
   "allTypes": "Alle Typen",
   "bulkActions": {
@@ -112,8 +109,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
+    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
   },
   "bulkDelete": {
     "confirmDescription": "Die ausgewählten Stücke und ihre Bilder werden endgültig gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -193,6 +190,7 @@
       "rotateLeft": "Nach links drehen",
       "rotateRight": "Nach rechts drehen",
       "setAsPrimary": "Als Hauptbild festlegen",
+      "suggestOutfit": "Outfit mit diesem Teil erstellen",
       "toggleFavorite": "Favorit umschalten",
       "undoBackgroundRemoval": "Hintergrundentfernung rückgängig machen"
     },

--- a/frontend/messages/de/wardrobe.json
+++ b/frontend/messages/de/wardrobe.json
@@ -85,7 +85,10 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
+    "rotateFailed": "Rotation failed",
+    "rotateQueued": "Queued for rotation",
+    "rotating": "Rotating…"
   },
   "allTypes": "Alle Typen",
   "bulkActions": {
@@ -109,8 +112,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
-    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
+    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
   },
   "bulkDelete": {
     "confirmDescription": "Die ausgewählten Stücke und ihre Bilder werden endgültig gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/frontend/messages/en/suggest.json
+++ b/frontend/messages/en/suggest.json
@@ -1,4 +1,18 @@
 {
+  "baseItem": {
+    "all": "All",
+    "basePiece": "Base item",
+    "change": "Change",
+    "chooseItem": "Choose a clothing item",
+    "chooseItemHint": "Select a shirt, pants, shoes, or any piece to build around",
+    "clear": "Clear",
+    "dialogDescription": "Select an item from your wardrobe to build this outfit around.",
+    "dialogTitle": "Choose an item for your outfit",
+    "mustInclude": "Must include",
+    "remove": "Remove",
+    "subtitle": "Choose a shirt, pants, shoes, or any item that must appear in the outfit",
+    "title": "Build around a specific piece (optional)"
+  },
   "dismissOutfit": "Dismiss outfit",
   "error": "Failed to generate outfit suggestion. Please try again.",
   "feedback": {
@@ -39,6 +53,14 @@
   },
   "loveIt": "Love it",
   "occasionPrompt": "What's the occasion?",
+  "options": {
+    "allOptions": "Compare All",
+    "chooseThis": "Choose this look",
+    "generateNew": "Generate 3 New Looks",
+    "optionNumber": "Look {number}",
+    "singleView": "Focus View",
+    "title": "{count} Outfit Options"
+  },
   "outfitPreview": {
     "familyRatings": {
       "average": "({rating} <star></star> avg)",

--- a/frontend/messages/en/wardrobe.json
+++ b/frontend/messages/en/wardrobe.json
@@ -85,7 +85,10 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
+    "rotateFailed": "Rotation failed",
+    "rotateQueued": "Queued for rotation",
+    "rotating": "Rotating…"
   },
   "allTypes": "All types",
   "bulkActions": {
@@ -107,10 +110,10 @@
     "removeBackgroundPartialFailed": "{count, plural, one {Failed to queue # item} other {Failed to queue # items}}",
     "removeBackgroundQueued": "{count, plural, one {Queued # item for background removal} other {Queued # items for background removal}}",
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
-    "rotateError": "Failed to rotate items",
-    "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
-    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
+    "rotateError": "Failed to queue rotation",
+    "rotatePartialFailed": "{count, plural, one {Failed to queue # item for rotation} other {Failed to queue # items for rotation}}",
+    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
   },
   "bulkDelete": {
     "confirmDescription": "This will permanently delete the selected items and their images. This action cannot be undone.",

--- a/frontend/messages/en/wardrobe.json
+++ b/frontend/messages/en/wardrobe.json
@@ -85,10 +85,7 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
-    "rotateFailed": "Rotation failed",
-    "rotateQueued": "Queued for rotation",
-    "rotating": "Rotating…"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
   },
   "allTypes": "All types",
   "bulkActions": {
@@ -110,10 +107,10 @@
     "removeBackgroundPartialFailed": "{count, plural, one {Failed to queue # item} other {Failed to queue # items}}",
     "removeBackgroundQueued": "{count, plural, one {Queued # item for background removal} other {Queued # items for background removal}}",
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
-    "rotateError": "Failed to queue rotation",
-    "rotatePartialFailed": "{count, plural, one {Failed to queue # item for rotation} other {Failed to queue # items for rotation}}",
-    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
+    "rotateError": "Failed to rotate items",
+    "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
+    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
   },
   "bulkDelete": {
     "confirmDescription": "This will permanently delete the selected items and their images. This action cannot be undone.",
@@ -193,6 +190,7 @@
       "rotateLeft": "Rotate left",
       "rotateRight": "Rotate right",
       "setAsPrimary": "Set as primary",
+      "suggestOutfit": "Create outfit with this item",
       "toggleFavorite": "Toggle favorite",
       "undoBackgroundRemoval": "Undo background removal"
     },

--- a/frontend/messages/fr/suggest.json
+++ b/frontend/messages/fr/suggest.json
@@ -1,4 +1,18 @@
 {
+  "baseItem": {
+    "all": "Tous",
+    "basePiece": "Pièce de base",
+    "change": "Changer",
+    "chooseItem": "Choisir un vêtement",
+    "chooseItemHint": "Sélectionnez une chemise, un pantalon, des chaussures ou une pièce maîtresse",
+    "clear": "Effacer",
+    "dialogDescription": "Sélectionnez un vêtement de votre garde-robe pour composer votre tenue autour.",
+    "dialogTitle": "Choisir un vêtement pour votre tenue",
+    "mustInclude": "À inclure obligatoirement",
+    "remove": "Supprimer",
+    "subtitle": "Choisissez une chemise, un pantalon, des chaussures ou un article qui doit figurer dans la tenue",
+    "title": "Composer autour d'une pièce spécifique (optionnel)"
+  },
   "dismissOutfit": "Ignorer la tenue",
   "error": "Échec de la génération de la suggestion de tenue. Veuillez réessayer.",
   "feedback": {
@@ -39,6 +53,14 @@
   },
   "loveIt": "J'adore",
   "occasionPrompt": "Quelle est l'occasion ?",
+  "options": {
+    "allOptions": "Tout comparer",
+    "chooseThis": "Choisir ce look",
+    "generateNew": "Générer 3 nouveaux looks",
+    "optionNumber": "Look {number}",
+    "singleView": "Vue détaillée",
+    "title": "{count} options de tenues"
+  },
   "outfitPreview": {
     "familyRatings": {
       "average": "({rating} <star></star> en moy.)",

--- a/frontend/messages/fr/wardrobe.json
+++ b/frontend/messages/fr/wardrobe.json
@@ -85,7 +85,10 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
+    "rotateFailed": "Rotation failed",
+    "rotateQueued": "Queued for rotation",
+    "rotating": "Rotating…"
   },
   "allTypes": "Tous les types",
   "bulkActions": {
@@ -109,8 +112,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
-    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
+    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
   },
   "bulkDelete": {
     "confirmDescription": "Cela supprimera définitivement les articles sélectionnés et leurs images. Cette action est irréversible.",

--- a/frontend/messages/fr/wardrobe.json
+++ b/frontend/messages/fr/wardrobe.json
@@ -85,10 +85,7 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
-    "rotateFailed": "Rotation failed",
-    "rotateQueued": "Queued for rotation",
-    "rotating": "Rotating…"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
   },
   "allTypes": "Tous les types",
   "bulkActions": {
@@ -112,8 +109,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
+    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
   },
   "bulkDelete": {
     "confirmDescription": "Cela supprimera définitivement les articles sélectionnés et leurs images. Cette action est irréversible.",
@@ -193,6 +190,7 @@
       "rotateLeft": "Rotation à gauche",
       "rotateRight": "Rotation à droite",
       "setAsPrimary": "Définir comme image principale",
+      "suggestOutfit": "Créer une tenue avec cet article",
       "toggleFavorite": "Basculer le favori",
       "undoBackgroundRemoval": "Annuler la suppression de l'arrière-plan"
     },

--- a/frontend/messages/it/suggest.json
+++ b/frontend/messages/it/suggest.json
@@ -1,4 +1,18 @@
 {
+  "baseItem": {
+    "all": "Tutti",
+    "basePiece": "Capo base",
+    "change": "Modifica",
+    "chooseItem": "Scegli un capo",
+    "chooseItemHint": "Seleziona una camicia, pantaloni, scarpe o un capo da cui partire",
+    "clear": "Cancella",
+    "dialogDescription": "Seleziona un capo dal tuo guardaroba attorno a cui costruire l'outfit.",
+    "dialogTitle": "Scegli un capo per il tuo outfit",
+    "mustInclude": "Da includere",
+    "remove": "Rimuovi",
+    "subtitle": "Scegli una camicia, pantaloni, scarpe o qualsiasi capo che deve comparire nell'outfit",
+    "title": "Costruisci attorno a un capo specifico (opzionale)"
+  },
   "dismissOutfit": "Ignora outfit",
   "error": "Generazione suggerimento outfit fallita. Riprova.",
   "feedback": {
@@ -39,6 +53,14 @@
   },
   "loveIt": "Mi piace",
   "occasionPrompt": "Qual è l'occasione?",
+  "options": {
+    "allOptions": "Confronta tutti",
+    "chooseThis": "Scegli questo look",
+    "generateNew": "Genera 3 nuovi look",
+    "optionNumber": "Look {number}",
+    "singleView": "Vista singola",
+    "title": "{count} opzioni di outfit"
+  },
   "outfitPreview": {
     "familyRatings": {
       "average": "({rating} <star></star> media)",

--- a/frontend/messages/it/wardrobe.json
+++ b/frontend/messages/it/wardrobe.json
@@ -85,10 +85,7 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
-    "rotateFailed": "Rotation failed",
-    "rotateQueued": "Queued for rotation",
-    "rotating": "Rotating…"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
   },
   "allTypes": "Tutti i tipi",
   "bulkActions": {
@@ -112,8 +109,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
+    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
   },
   "bulkDelete": {
     "confirmDescription": "Questo eliminerà definitivamente i capi selezionati e le relative immagini. Questa azione non può essere annullata.",
@@ -193,7 +190,8 @@
       "rotateLeft": "Ruota a sinistra",
       "rotateRight": "Ruota a destra",
       "setAsPrimary": "Imposta come principale",
-      "toggleFavorite": "Attiva/disattiva preferito",
+      "suggestOutfit": "Crea outfit con questo capo",
+      "toggleFavorite": "Aggiungi/rimuovi dai preferiti",
       "undoBackgroundRemoval": "Annulla rimozione sfondo"
     },
     "type": "Tipo",

--- a/frontend/messages/it/wardrobe.json
+++ b/frontend/messages/it/wardrobe.json
@@ -85,7 +85,10 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
+    "rotateFailed": "Rotation failed",
+    "rotateQueued": "Queued for rotation",
+    "rotating": "Rotating…"
   },
   "allTypes": "Tutti i tipi",
   "bulkActions": {
@@ -109,8 +112,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
-    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
+    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
   },
   "bulkDelete": {
     "confirmDescription": "Questo eliminerà definitivamente i capi selezionati e le relative immagini. Questa azione non può essere annullata.",

--- a/frontend/messages/ja/suggest.json
+++ b/frontend/messages/ja/suggest.json
@@ -1,4 +1,18 @@
 {
+  "baseItem": {
+    "all": "すべて",
+    "basePiece": "ベースアイテム",
+    "change": "変更",
+    "chooseItem": "アイテムを選択",
+    "chooseItemHint": "シャツ、パンツ、靴など、コーデの軸にするアイテムを選択",
+    "clear": "クリア",
+    "dialogDescription": "ワードローブからコーデのベースにするアイテムを選択してください。",
+    "dialogTitle": "コーデのアイテムを選択",
+    "mustInclude": "必須アイテム",
+    "remove": "削除",
+    "subtitle": "コーデに必ず含めたいシャツ、パンツ、靴などを選んでください",
+    "title": "特定のアイテムをベースに作成（任意）"
+  },
   "dismissOutfit": "このコーデを見送る",
   "error": "コーデ提案の生成に失敗しました。もう一度お試しください。",
   "feedback": {
@@ -39,6 +53,14 @@
   },
   "loveIt": "最高",
   "occasionPrompt": "どんなシーンですか？",
+  "options": {
+    "allOptions": "すべて比較",
+    "chooseThis": "このコーデを選ぶ",
+    "generateNew": "新しく3パターン作成",
+    "optionNumber": "コーデ {number}",
+    "singleView": "個別表示",
+    "title": "{count}つのコーデ提案"
+  },
   "outfitPreview": {
     "familyRatings": {
       "average": "（平均 {rating} <star></star>）",

--- a/frontend/messages/ja/wardrobe.json
+++ b/frontend/messages/ja/wardrobe.json
@@ -85,7 +85,10 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
+    "rotateFailed": "Rotation failed",
+    "rotateQueued": "Queued for rotation",
+    "rotating": "Rotating…"
   },
   "allTypes": "すべてのタイプ",
   "bulkActions": {
@@ -109,8 +112,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
-    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
+    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
   },
   "bulkDelete": {
     "confirmDescription": "選択したアイテムと画像を完全に削除します。この操作は取り消せません。",

--- a/frontend/messages/ja/wardrobe.json
+++ b/frontend/messages/ja/wardrobe.json
@@ -85,10 +85,7 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
-    "rotateFailed": "Rotation failed",
-    "rotateQueued": "Queued for rotation",
-    "rotating": "Rotating…"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
   },
   "allTypes": "すべてのタイプ",
   "bulkActions": {
@@ -112,8 +109,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
+    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
   },
   "bulkDelete": {
     "confirmDescription": "選択したアイテムと画像を完全に削除します。この操作は取り消せません。",
@@ -192,8 +189,9 @@
       "replaceImage": "画像を置き換え",
       "rotateLeft": "左に回転",
       "rotateRight": "右に回転",
-      "setAsPrimary": "メインに設定",
-      "toggleFavorite": "お気に入りを切替",
+      "setAsPrimary": "メイン画像に設定",
+      "suggestOutfit": "このアイテムでコーデを作成",
+      "toggleFavorite": "お気に入りを切り替え",
       "undoBackgroundRemoval": "背景削除を元に戻す"
     },
     "type": "タイプ",

--- a/frontend/messages/ko/suggest.json
+++ b/frontend/messages/ko/suggest.json
@@ -1,4 +1,18 @@
 {
+  "baseItem": {
+    "all": "전체",
+    "basePiece": "기본 아이템",
+    "change": "변경",
+    "chooseItem": "의류 아이템 선택",
+    "chooseItemHint": "셔츠, 바지, 신발 등 코디의 기준이 될 아이템을 선택하세요",
+    "clear": "초기화",
+    "dialogDescription": "코디의 기준이 될 옷을 옷장에서 선택하세요.",
+    "dialogTitle": "코디할 아이템 선택",
+    "mustInclude": "반드시 포함",
+    "remove": "제거",
+    "subtitle": "코디에 반드시 포함되어야 하는 셔츠, 바지, 신발 등을 선택하세요",
+    "title": "특정 아이템을 기준으로 코디 만들기 (선택)"
+  },
   "dismissOutfit": "코디 닫기",
   "error": "코디 추천 생성에 실패했어요. 다시 시도해 주세요.",
   "feedback": {
@@ -39,6 +53,14 @@
   },
   "loveIt": "마음에 들어요",
   "occasionPrompt": "어떤 상황인가요?",
+  "options": {
+    "allOptions": "모두 비교",
+    "chooseThis": "이 코디 선택",
+    "generateNew": "새로운 3가지 코디 생성",
+    "optionNumber": "코디 {number}",
+    "singleView": "개별 보기",
+    "title": "{count}가지 코디 옵션"
+  },
   "outfitPreview": {
     "familyRatings": {
       "average": "(평균 {rating} <star></star>)",

--- a/frontend/messages/ko/wardrobe.json
+++ b/frontend/messages/ko/wardrobe.json
@@ -85,7 +85,10 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
+    "rotateFailed": "Rotation failed",
+    "rotateQueued": "Queued for rotation",
+    "rotating": "Rotating…"
   },
   "allTypes": "전체 유형",
   "bulkActions": {
@@ -109,8 +112,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
-    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
+    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
   },
   "bulkDelete": {
     "confirmDescription": "선택한 아이템과 이미지가 영구적으로 삭제돼요. 이 작업은 되돌릴 수 없어요.",

--- a/frontend/messages/ko/wardrobe.json
+++ b/frontend/messages/ko/wardrobe.json
@@ -85,10 +85,7 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
-    "rotateFailed": "Rotation failed",
-    "rotateQueued": "Queued for rotation",
-    "rotating": "Rotating…"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
   },
   "allTypes": "전체 유형",
   "bulkActions": {
@@ -112,8 +109,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
+    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
   },
   "bulkDelete": {
     "confirmDescription": "선택한 아이템과 이미지가 영구적으로 삭제돼요. 이 작업은 되돌릴 수 없어요.",
@@ -193,6 +190,7 @@
       "rotateLeft": "왼쪽 회전",
       "rotateRight": "오른쪽 회전",
       "setAsPrimary": "대표 이미지로 설정",
+      "suggestOutfit": "이 아이템으로 코디 만들기",
       "toggleFavorite": "즐겨찾기 전환",
       "undoBackgroundRemoval": "배경 제거 취소"
     },

--- a/frontend/messages/zh-CN/suggest.json
+++ b/frontend/messages/zh-CN/suggest.json
@@ -1,4 +1,18 @@
 {
+  "baseItem": {
+    "all": "全部",
+    "basePiece": "基础单品",
+    "change": "更改",
+    "chooseItem": "选择衣物",
+    "chooseItemHint": "选择衬衫、裤子、鞋子或作为主体的单品",
+    "clear": "清除",
+    "dialogDescription": "从衣橱中选择一件单品来围绕其搭配穿搭。",
+    "dialogTitle": "为穿搭选择单品",
+    "mustInclude": "必须包含",
+    "remove": "移除",
+    "subtitle": "选择一件必须包含在穿搭中的衬衫、裤子、鞋子或单品",
+    "title": "围绕特定单品搭配（可选）"
+  },
   "dismissOutfit": "关闭穿搭",
   "error": "生成穿搭建议失败，请重试。",
   "feedback": {
@@ -39,6 +53,14 @@
   },
   "loveIt": "喜欢",
   "occasionPrompt": "今天什么场合？",
+  "options": {
+    "allOptions": "全部对比",
+    "chooseThis": "选择这套穿搭",
+    "generateNew": "重新生成3套穿搭",
+    "optionNumber": "搭配 {number}",
+    "singleView": "单套查看",
+    "title": "{count}套穿搭方案"
+  },
   "outfitPreview": {
     "familyRatings": {
       "average": "（平均 {rating} <star></star>）",

--- a/frontend/messages/zh-CN/wardrobe.json
+++ b/frontend/messages/zh-CN/wardrobe.json
@@ -85,7 +85,10 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
+    "rotateFailed": "Rotation failed",
+    "rotateQueued": "Queued for rotation",
+    "rotating": "Rotating…"
   },
   "allTypes": "所有类型",
   "bulkActions": {
@@ -109,8 +112,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
-    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
+    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
   },
   "bulkDelete": {
     "confirmDescription": "这将永久删除所选单品及其图片。此操作不可撤销。",

--- a/frontend/messages/zh-CN/wardrobe.json
+++ b/frontend/messages/zh-CN/wardrobe.json
@@ -85,10 +85,7 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
-    "rotateFailed": "Rotation failed",
-    "rotateQueued": "Queued for rotation",
-    "rotating": "Rotating…"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
   },
   "allTypes": "所有类型",
   "bulkActions": {
@@ -112,8 +109,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
+    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
   },
   "bulkDelete": {
     "confirmDescription": "这将永久删除所选单品及其图片。此操作不可撤销。",
@@ -193,6 +190,7 @@
       "rotateLeft": "向左旋转",
       "rotateRight": "向右旋转",
       "setAsPrimary": "设为主图",
+      "suggestOutfit": "用这件衣物创建穿搭",
       "toggleFavorite": "切换收藏",
       "undoBackgroundRemoval": "撤销背景去除"
     },

--- a/frontend/messages/zh-TW/suggest.json
+++ b/frontend/messages/zh-TW/suggest.json
@@ -1,4 +1,18 @@
 {
+  "baseItem": {
+    "all": "全部",
+    "basePiece": "基礎單品",
+    "change": "更改",
+    "chooseItem": "選擇衣物",
+    "chooseItemHint": "選擇襯衫、長褲、鞋子或作為主體的單品",
+    "clear": "清除",
+    "dialogDescription": "從衣櫥中選擇一件單品來圍繞其搭配穿搭。",
+    "dialogTitle": "為穿搭選擇單品",
+    "mustInclude": "必須包含",
+    "remove": "移除",
+    "subtitle": "選擇一件必須包含在穿搭中的襯衫、長褲、鞋子或單品",
+    "title": "圍繞特定單品搭配（選填）"
+  },
   "dismissOutfit": "關閉穿搭",
   "error": "產生穿搭建議失敗，請重試。",
   "feedback": {
@@ -39,6 +53,14 @@
   },
   "loveIt": "超喜歡",
   "occasionPrompt": "什麼場合？",
+  "options": {
+    "allOptions": "全部對比",
+    "chooseThis": "選擇這套穿搭",
+    "generateNew": "重新生成3套穿搭",
+    "optionNumber": "搭配 {number}",
+    "singleView": "單套檢視",
+    "title": "{count}套穿搭方案"
+  },
   "outfitPreview": {
     "familyRatings": {
       "average": "（平均 {rating} <star></star>）",

--- a/frontend/messages/zh-TW/wardrobe.json
+++ b/frontend/messages/zh-TW/wardrobe.json
@@ -85,7 +85,10 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
+    "rotateFailed": "Rotation failed",
+    "rotateQueued": "Queued for rotation",
+    "rotating": "Rotating…"
   },
   "allTypes": "所有類型",
   "bulkActions": {
@@ -109,8 +112,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
-    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
+    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
   },
   "bulkDelete": {
     "confirmDescription": "這將永久刪除所選單品及其圖片。此操作無法復原。",

--- a/frontend/messages/zh-TW/wardrobe.json
+++ b/frontend/messages/zh-TW/wardrobe.json
@@ -85,10 +85,7 @@
     "removeBackgroundQueued": "Queued for background removal",
     "removingBackground": "Removing background...",
     "removingBackgroundElapsed": "Removing background… {elapsed}",
-    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}",
-    "rotateFailed": "Rotation failed",
-    "rotateQueued": "Queued for rotation",
-    "rotating": "Rotating…"
+    "retryCooldown": "{seconds, plural, one {Retry available in # second} other {Retry available in # seconds}}"
   },
   "allTypes": "所有類型",
   "bulkActions": {
@@ -112,8 +109,8 @@
     "removeBackgroundSkipped": "{count, plural, one {# item already processing} other {# items already processing}}",
     "rotateError": "Failed to rotate items",
     "rotatePartialFailed": "{count, plural, one {Failed to rotate # item} other {Failed to rotate # items}}",
-    "rotateQueued": "{count, plural, one {Queued # item for rotation} other {Queued # items for rotation}}",
-    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}"
+    "rotateSkipped": "{count, plural, one {# item skipped (already processing)} other {# items skipped (already processing)}}",
+    "rotateSuccess": "{count, plural, one {# item rotated} other {# items rotated}}"
   },
   "bulkDelete": {
     "confirmDescription": "這將永久刪除所選單品及其圖片。此操作無法復原。",
@@ -193,6 +190,7 @@
       "rotateLeft": "向左旋轉",
       "rotateRight": "向右旋轉",
       "setAsPrimary": "設為主要",
+      "suggestOutfit": "用這件衣物建立穿搭",
       "toggleFavorite": "切換收藏",
       "undoBackgroundRemoval": "復原背景移除"
     },


### PR DESCRIPTION
### Summary
Improves the outfit suggestion experience by adding:
1. **Base Item Selection**: The option to generate complete outfits centered around a specific piece of clothing (e.g. a favorite shirt, pants, or shoes).
2. **3-Look Comparison View**: The option to switch between Look 1 / Look 2 / Look 3 tabs or view all 3 AI-generated outfit suggestions simultaneously in a side-by-side comparison grid, rather than needing to view and discard them sequentially.

### Features & Changes
- **Backend API (`POST /api/v1/outfits/suggest-options`)**:
  - Adds endpoint to generate and materialize all 3 AI outfit recommendations in a single request.
  - Supports `include_items: list[UUID]` in suggestion requests, forcing the AI prompt and outfit assembler to include the selected item(s).
  - Enforces mandatory item retention during body-slot deduplication and canonical outfit sorting.
  - Updates suggestion cache key (`suggest:{user_id}:{occasion}:{sorted_item_ids}`) and FIFO pop to isolate suggestions with specific base items.
  - Adds recency combination filtering to avoid repeating recently suggested looks across alternatives.
- **Frontend Dashboard (`/dashboard/suggest`)**:
  - Adds a base item picker card and dialog with category filtering (shirts, pants, shoes, etc.) to choose a piece to build outfits around.
  - Adds a *"Create outfit with this item"* quick action in the wardrobe item details modal (`item-detail-dialog.tsx`) that routes directly to `/dashboard/suggest?item=<id>`.
  - Introduces Look 1 / Look 2 / Look 3 tabs for instant switching between alternatives.
  - Adds a **"Compare All"** toggle button that expands the view into a 3-column side-by-side comparison grid with individual *"Choose This"* actions.
- **Internationalization (i18n)**:
  - Added full translation coverage for all new UI strings across all 8 supported locales (`en`, `de`, `fr`, `it`, `ja`, `ko`, `zh-CN`, `zh-TW`). Verified with `npm run i18n:check`.
- **Testing**:
  - Added unit and integration tests for `include_items` enforcement, `suggest-options` batch endpoint, body-slot overrides, and suggestion cache isolation.

### Verification
- `npm run build` in `frontend/` succeeds cleanly.
- `npm run i18n:check` passes with 0 missing keys / errors across all 8 locales.
- All 71 backend tests pass in `test_clothing_utils.py`, `test_suggestion_cache.py`, and `test_recommendation_service.py`.

## Summary by Sourcery

Improve outfit suggestions by supporting base-item-driven recommendations and comparison of three generated looks.

New Features:
- Enable outfit suggestions to be generated around a selected wardrobe item.
- Provide three generated outfit options with tabbed navigation and side-by-side comparison.

Bug Fixes:
- Ensure selected base items are retained during outfit assembly and body-slot deduplication.
- Prevent suggestion-cache variants from mixing across different base-item selections.
- Avoid repeating recently suggested outfit combinations.

Enhancements:
- Add a wardrobe-item quick action that opens outfit suggestions with that item preselected.
- Preserve the existing single-outfit suggestion API while supporting batched recommendation generation.

Tests:
- Add coverage for mandatory item enforcement, multi-option suggestions, cache isolation, and bulk deletion limits.

Chores:
- Add translations for the new suggestion and wardrobe actions across all supported locales.