### PR TITLE
fix(wardrobe): keep item detail actions visible with long names

### DIFF
--- a/frontend/components/item-detail-dialog.tsx
+++ b/frontend/components/item-detail-dialog.tsx
@@ -269,17 +269,22 @@ export function ItemDetailDialog({ item, open, onOpenChange }: ItemDetailDialogP
         <DialogContent className="sm:max-w-2xl max-h-[90vh] flex flex-col p-0 overflow-hidden [&>button]:hidden">
           {/* Header - sticky */}
           <DialogHeader className="flex flex-row items-center gap-2 space-y-0 p-4 border-b flex-shrink-0">
-            {/* Capped on narrow screens because the title claims its content
-                width before the actions do, and a long item name otherwise
-                squeezes the scrollable row down to about one button. */}
-            <DialogTitle className="text-xl min-w-0 truncate max-w-[45%] sm:max-w-none">
+            {/* Below sm the title keeps its 45% cap and the actions stay in a
+                scrollable row, so the close control is always reachable on a
+                phone. From sm up the title becomes the flexible item and the
+                actions row is sized to its content instead, so every action
+                stays visible and the name truncates. Previously the title had
+                no cap at all from sm up: because a flex item claims its content
+                width before a flex-1 sibling does, a long name squeezed the
+                actions row and pushed edit and replace-image out of view. */}
+            <DialogTitle className="text-xl min-w-0 truncate max-w-[45%] sm:max-w-none sm:flex-1">
               {item.name || (typeInfo ? typeInfo.label : item.type)}
             </DialogTitle>
             {/* The action row scrolls sideways once it stops fitting, because
                 the dialog clips its own overflow: without this the buttons
                 push the close control past the right edge on a phone and it
                 cannot be reached at all. */}
-            <div className="flex-1 min-w-0 overflow-x-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            <div className="flex-1 min-w-0 overflow-x-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:flex-none">
               <div className="flex w-max ml-auto items-center gap-1">
                 <Button
                   variant="ghost"


### PR DESCRIPTION
## Description

The item detail dialog header drops action buttons when an item has a long
name. The edit control disappeared on my wardrobe, and a longer name took its
neighbours with it.

`DialogTitle` carried `max-w-[45%] sm:max-w-none`, so from `sm` up the title
had no cap. A flex item claims its content width before a `flex-1` sibling
does, so the title took the space the actions row needed and the row
collapsed. The row hides its scrollbar too, so nothing suggests the missing
buttons are still scrolled off to the right.

The existing comment already describes this failure for narrow screens, where
a 45% cap handles it. That cap was not applied at wider breakpoints.

The fix leaves mobile behaviour alone and swaps the priority from `sm` up: the
title becomes the flexible item and the actions row is sized to its content,
so every action stays visible and the name truncates.

## Related Issue

No issue filed. Reproduction is in the Testing section below.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My code follows the project's coding style
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes don't introduce new warnings or errors

No test is included. This is a Tailwind class change and I could not see an
existing suite it would fit into. Happy to add one if you have a preferred
approach for layout regressions.

## Testing

Built the frontend image from this branch and ran it against the same backend
and the same item as the released build, so the only difference between the
two screenshots below is this change. The item is named
"Brandon PantBrandon PantBrandon Pant" and has nine actions available.

### Test Environment
- [x] Docker Compose

### Tests Performed

- Released build: the title renders at full width and only 5 of the 9 actions
  are visible. Remove background, undo background removal, replace image and
  edit are all pushed out of the row.
- This branch: the title truncates and all 9 actions are visible, plus close.
- Short names render as before.

I first tried removing `sm:max-w-none` so the 45% cap applied at every width.
That was not enough: the title truncated, but with every conditional action
rendered (remove background and undo background removal both present), edit
and replace-image were still clipped. Sizing the actions row to its content
from `sm` up is what fixes it.

## Screenshots (if applicable)
Before: 
<img width="697" height="98" alt="image" src="https://github.com/user-attachments/assets/902a295a-efc9-4f30-b660-b2bdef148831" />

After:
<img width="691" height="85" alt="image" src="https://github.com/user-attachments/assets/4eb9f9ee-fd76-4672-a6b8-4073e7299333" />


## Additional Notes

The action row keeps `overflow-x-auto` below `sm`, so the phone behaviour the
original comment protects is preserved.

## Summary by Sourcery

Bug Fixes:
- Keep all item detail dialog actions visible on wider screens when item names are long by truncating the title instead of allowing it to displace the actions.